### PR TITLE
Fix old formatting and spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 University of California OSPO Network
 
 This repo is a work in progress
-It will include the resources for building the UC OSPO Network website as well as materials related to the network's actitives.
+It will include the resources for building the UC OSPO Network website as well as materials related to the network's activities.

--- a/content/guiding-themes/sustainability.md
+++ b/content/guiding-themes/sustainability.md
@@ -29,12 +29,12 @@ Open-source software is often created to accomplish a research goal. We want to 
 
 ## Team Members
 
-**Peter Brantley, UC Davis Campus CoPI**
-**Vladimir Filkov, UC Davis Campus CoPI**
-**Amber Budden, UCSB Campus CoPI**
-**Jonathan Balkind, UCSB Campus CoPI**
-**Vessela Ensberg, UC Davis**
-**Priyal Soni, UC Davis, GSR**
-**Greg Janee, UCSB**
-**Justin Merz, UC Davis**
-**Renata Curty, UCSB**
+- Peter Brantley, UC Davis Campus CoPI
+- Vladimir Filkov, UC Davis Campus CoPI
+- Amber Budden, UCSB Campus CoPI
+- Jonathan Balkind, UCSB Campus CoPI
+- Vessela Ensberg, UC Davis
+- Priyal Soni, UC Davis, GSR
+- Greg Janee, UCSB
+- Justin Merz, UC Davis
+- Renata Curty, UCSB

--- a/content/guiding-themes/sustainability.md
+++ b/content/guiding-themes/sustainability.md
@@ -29,20 +29,12 @@ Open-source software is often created to accomplish a research goal. We want to 
 
 ## Team Members
 
-#### Peter Brantley, UC Davis Campus CoPI
-
-#### Vladimir Filkov, UC Davis Campus CoPI
-
-#### Amber Budden, UCSB Campus CoPI
-
-#### Jonathan Balkind, UCSB Campus CoPI
-
-#### Vessela Ensberg, UC Davis
-
-#### Priyal Soni, UC Davis, GSR
-
-#### Greg Janee, UCSB
-
-#### Justin Merz, UC Davis
-
-#### Renata Curty, UCSB
+**Peter Brantley, UC Davis Campus CoPI**
+**Vladimir Filkov, UC Davis Campus CoPI**
+**Amber Budden, UCSB Campus CoPI**
+**Jonathan Balkind, UCSB Campus CoPI**
+**Vessela Ensberg, UC Davis**
+**Priyal Soni, UC Davis, GSR**
+**Greg Janee, UCSB**
+**Justin Merz, UC Davis**
+**Renata Curty, UCSB**

--- a/content/posts/charting-a-course/index.md
+++ b/content/posts/charting-a-course/index.md
@@ -44,7 +44,7 @@ Morning sessions included:
    Facilitated by David Minor (UCSD) and Erik Mitchell (UCSD), discussions centered on defining the roles and responsibilities within the OSPO Leadership Group (OLG) and working groups, as well as the governance structure between campuses.
    We defined the membership and responsibilities of the OLG and working groups, and discussed the governance structure between the OLG, campuses, and working groups.
 
-The afternoon was dedicated to thematic discussions on Discovery, Sustainability, and Education before continuing our Timeline and Deliverable discussion:
+   The afternoon was dedicated to thematic discussions on Discovery, Sustainability, and Education before continuing our Timeline and Deliverable discussion:
 
 6. **Discovery Theme.**
    Facilitated by Amber Budden (UCSB) and Emily Lovell (UCSC), the priority is to get the GitHub scraping run at each of the campuses to enable discovery of open source projects and the development of a UC Open Source Repository Browser (ORB).
@@ -59,7 +59,7 @@ The afternoon was dedicated to thematic discussions on Discovery, Sustainability
    We discussed gathering metadata and organizing educational resources, connecting with Teaching Open Source and other OSPO communities, and exploring the Carpentries Incubator and Lab for developing courses.
    We also brainstormed around early events like Hacktoberfest@UCSC in Fall 2024 and workshops on understanding large codebases with GitHub Copilot.
 
-Over the next few months, our focus will be on finalizing the project governance and management approach, branding and communications strategy, and advancing the work in the three thematic areas.
+   Over the next few months, our focus will be on finalizing the project governance and management approach, branding and communications strategy, and advancing the work in the three thematic areas.
 
 As the UC-wide network of OSPOs moves forward, it is poised to play a pivotal role in advancing open-source principles and practices across the UC system.
 With the support of the Alfred P. Sloan Foundation and the collective efforts of the UC campuses, the network is excited to embark on this journey towards a more open, collaborative, and innovative future.

--- a/content/santa-barbara/_index.md
+++ b/content/santa-barbara/_index.md
@@ -11,23 +11,23 @@ alt = "UCSB OSPO Logo"
 
 UC Santa Barbara is one of the six campus partners in the UC Network of Open Source Program Offices (OSPOs) focussed on supporting developers and users of Open Source through the discovery and indexing of UC developed Open Source; development of educational materials, curricula and best practices guidelines; and services and guides in support of Open Source sustainability.
 
-**OSS at UCSB**
+## OSS at UCSB
 
 UC Santa Barbara has an established history in open source software development and community OSS contribution, in addition to leadership in open science principles and practices. Expertise is distributed across the campus community and OSS development extends from small exploratory research projects, to established community adopted systems, to administrative infrastructure and more. Additionally, UCSB as a community invests significantly in community developed open tools and systems for the benefit of the campus and broader communities.
 
-**How is UCSB supporting the local OSS community?**
+## How is UCSB supporting the local OSS community?
 
 At present, UCSB does not have a dedicated OSPO. Through the collaborative Alfred. P Sloan Foundation grant, we will be able to conduct landscape analysis on the state of OSS at UCSB to better inform future services and resources, develop a cross-campus open-source community of practitioners and users, and make available the opportunities, materials, and services developed in collaboration with UC partners. These activities will be coordinated through the UCSB Library as a cross-domain center for scholarship and information literacy.
 
-**What would an OSPO at UCSB look like?**
+## What would an OSPO at UCSB look like?
 
 We foresee an OSPO advising on open source licenses, fostering community engagement, and promoting best practices for creating and utilizing sustainable open source technology. By facilitating collaboration and innovation, our OSPO would help our campus to leverage the full potential of open source. We are still defining what our OSPO would be and are interested in hearing your perspectives on how an OSPO could serve your needs. We encourage you to get in touch!
 
-**Get connected**
+## Get connected
 
-We are excited to build community among the UCSB population of Open Source practitioners. To stay informed about campus initiatives, learn more about the UC OSPO network, or to support us in the development of a UCSB OSPO, reach out via ospo@library.ucsb.edu.
+We are excited to build community among the UCSB population of Open Source practitioners. To stay informed about campus initiatives, learn more about the UC OSPO network, or to support us in the development of a UCSB OSPO, [reach out to us](mailto:ospo@library.ucsb.edu).
 
-**Resources:**
+## Resources
 
 - [Announcement of Sloan funded UC OSPO Network](https://news.ucsb.edu/in-focus/new-grant-supports-creation-uc-network-open-source-program-offices)
 - [UC OSPO Network](https://ucospo.net)


### PR DESCRIPTION
Fixes a few formatting issues in existing files that my Markdown linter yells at me about whenever I work on the website. They're also accessibility impediments for folks who use screen readers or navigate exclusively by keyboard. Just things like using headings as emphasis (create a navigation structure where there shouldn't be one) or vice versa: using emphasis instead of headings (breaking navigation).