### PR TITLE
Add repeating event info

### DIFF
--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -6,6 +6,10 @@ title: Events
 
 <iframe src="https://calendar.google.com/calendar/embed?src=c_ecaa1e020fad0705c72bf19ac9502b0fb7d9dbc2ffd9f057d79f5bbfdeca9711%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 
+{{< admonition tip >}}
+Please note: if you add an event from the embedded calendar above, it will default to 'Does not repeat'". If you'd like to add all instances of a recurring event, please use the .ics file or the "Add to your Google calendar" button for the event below.
+{{< /admonition >}}
+
 ## Upcoming Events
 
 ### Virtual Coffee/Office Hours (ongoing)


### PR DESCRIPTION
Partially addresses #147 by adding an admonition below the embedded calendar about it defaulting to "Does not repeat". People could instead manually change the repetition info, but I decided against saying that because it requires them to do some work to figure out what the repetition interval is *supposed* to be, whereas using the .ics file or the "Add to your Google calendar" button will handle the repetition correctly.