### PR TITLE
Add blog post: OSSPREY announcement

### DIFF
--- a/content/posts/ossprey-announcement/index.md
+++ b/content/posts/ossprey-announcement/index.md
@@ -4,11 +4,11 @@ date: 2025-09-11T10:00:00-07:00
 draft: false
 summary: "OSSPREY delivers AI-powered sustainability forecasting and evidence-based recommendations to help maintainers keep projects healthy."
 tags: ["sustainability", "open source", "forecasting", "AI"]
-authors: ["Nafiz Imtiaz Khan"]
+authors: ["Nafiz Imtiaz Khan", "Priyal Soni", "Arjun Ashok", "Vladimir Filkov"]
 featuredImage: "https://raw.githubusercontent.com/OSS-PREY/OSSPREY-Website/refs/heads/main/static/images/ossprey-dashboard.png"
 ---
 
-Open Source Software (OSS) powers everything from academic research to mission‑critical infrastructure at tech giants. Yet, over **90% of OSS projects experience stagnation or abandonment**. The question is no longer whether OSS matters, but _how to ensure its sustainability_.
+Open Source Software (OSS) powers everything from academic research to mission-critical infrastructure at tech giants. Yet, over **90% of OSS projects experience stagnation or abandonment**. The question is no longer whether OSS matters, but _how to ensure its sustainability_.
 
 ## Meet OSSPREY
 
@@ -16,36 +16,36 @@ The OSSPREY paper has been accepted in the [Automated Software Engineering 2025 
 
 ![OSSPREY Icon](https://oss-prey.github.io/OSSPREY-Website/static/images/favicon.ico)
 
-**OSSPREY (Open Source Software PRoject sustainabilitY tracker)** is an intelligent, modular, and research‑backed platform that enables open source maintainers to anticipate and address project health issues before they become critical. Developed by the DECAL Lab at UC Davis, OSSPREY uniquely combines real‑time GitHub data scraping, socio‑technical network modeling, machine learning forecasting, and a curated knowledge base of interventions grounded in software engineering research.
+**OSSPREY (Open Source Software PRoject sustainabilitY tracker)** is an intelligent, modular, and research-backed platform that enables open source maintainers to anticipate and address project health issues before they become critical. Developed by the DECAL Lab at UC Davis, OSSPREY uniquely combines real-time GitHub data scraping, socio-technical network modeling, machine learning forecasting, and a curated knowledge base of interventions grounded in software engineering research.
 
-By analyzing both technical contributions (e.g., commits, file changes) and social signals (e.g., issue discussions, collaboration patterns), OSSPREY delivers comprehensive month‑by‑month sustainability forecasts. What truly sets it apart is its ReACT recommendation engine, which maps empirical research findings to tailored, actionable strategies maintainers can deploy to counteract emerging risks—such as declining contributor activity, fragmented communication, or stagnant issue resolution.
+By analyzing both technical contributions (e.g., commits, file changes) and social signals (e.g., issue discussions, collaboration patterns), OSSPREY delivers comprehensive month-by-month sustainability forecasts. What truly sets it apart is its ReACT recommendation engine, which maps empirical research findings to tailored, actionable strategies maintainers can deploy to counteract emerging risks—such as declining contributor activity, fragmented communication, or stagnant issue resolution.
 
-> “OSSPREY bridges the gap between academic sustainability metrics and real‑world decision making by providing both forecasts and evidence‑based recommendations.”
+> “OSSPREY bridges the gap between academic sustainability metrics and real-world decision making by providing both forecasts and evidence-based recommendations.”
 
 ## Why OSSPREY Matters
 
 Traditional metrics like issue count or commit frequency don’t tell the full story. OSSPREY moves beyond snapshots and offers:
 
-- **Real‑time monitoring** of GitHub projects using socio‑technical networks.
-- **Month‑by‑month sustainability forecasts** powered by a transformer model with 94% F1‑score accuracy.
-- **Actionable ReACTs** — evidence‑based interventions curated from 186 empirical studies.
+- **Real-time monitoring** of GitHub projects using socio-technical networks.
+- **Month-by-month sustainability forecasts** powered by a transformer model with 94% F1-score accuracy.
+- **Actionable ReACTs** — evidence-based interventions curated from 186 empirical studies.
 - **Interactive network visualizations** showing communication and technical dependencies.
 
 ## How It Works
 
 OSSPREY’s pipeline includes four key modules:
 
-- **Scraper:** Rust‑based module collects commits, issues, and metadata monthly via GitHub GraphQL API.
+- **Scraper:** Rust-based module collects commits, issues, and metadata monthly via GitHub GraphQL API.
 - **Network Generator:** Builds social and technical networks to map collaboration and file ownership.
 - **Forecaster:** Transformer model forecasts future sustainability based on historical network features.
-- **ReACT‑Recommender:** Suggests empirically validated strategies when sustainability dips.
+- **ReACT-Recommender:** Suggests empirically validated strategies when sustainability dips.
 
-![OSSPREY dashboard with forecast trajectories, socio‑technical networks, and actionable suggestions](https://raw.githubusercontent.com/OSS-PREY/OSSPREY-Website/refs/heads/main/static/images/ossprey-dashboard.png)
+![OSSPREY dashboard with forecast trajectories, socio-technical networks, and actionable suggestions](https://raw.githubusercontent.com/OSS-PREY/OSSPREY-Website/refs/heads/main/static/images/ossprey-dashboard.png)
 
 ## Dashboard Highlights
 
 - **Forecast Graph:** Visualizes project sustainability with branching future scenarios (positive, neutral, negative).
-- **Actionables Panel:** Ranks interventions by impact level and relevance. Each is linked to peer‑reviewed research.
+- **Actionables Panel:** Ranks interventions by impact level and relevance. Each is linked to peer-reviewed research.
 - **Social + Technical Network:** View developer interaction and technical load distribution via interactive Sankey charts.
 - **Project Metadata:** Stargazers, forks, sponsors, contributor trends, and more contextual insights.
 
@@ -64,7 +64,7 @@ Getting started is straightforward: register for a free account and sign in with
 
 ## Future Directions
 
-We’re working on integrating dependency‑aware forecasting, personalized suggestions using LLMs, and parallelism upgrades for large‑scale project scraping. OSSPREY is open‑source and actively maintained—contributions and feedback are welcome!
+We’re working on integrating dependency-aware forecasting, personalized suggestions using LLMs, and parallelism upgrades for large-scale project scraping. OSSPREY is open-source and actively maintained—contributions and feedback are welcome!
 
 ### Resources
 
@@ -72,4 +72,4 @@ We’re working on integrating dependency‑aware forecasting, personalized sugg
 - [API Documentation](https://oss-prey.github.io/OSSPREY-Website/#API)
 - [Feature Set](https://oss-prey.github.io/OSSPREY-Website/#Features)
 
-Built by the DECAL Lab at UC Davis, OSSPREY is paving the way for data‑driven, evidence‑based OSS sustainability. Empower your project with proactive insights today.
+Built by the DECAL Lab at UC Davis, OSSPREY is paving the way for data-driven, evidence-based OSS sustainability. Empower your project with proactive insights today.


### PR DESCRIPTION
This PR adds a new blog post titled “Introducing OSSPREY: AI-Powered Forecasting and Actionable Insights for OSS Sustainability” under content/posts/ossprey-announcement/index.md. The post highlights OSSPREY’s motivation, technical pipeline, dashboard features, and acceptance in the ASE 2025 Tool Demonstration Track. Images are externally hosted, so no static assets are included.