### PR TITLE
set up github pages to move from netlify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,8 @@ jobs:
       - run: npx linkinator ./_build/html/
 
       - name: Accessibility check
-        # pa11y-ci needs a running server to crawl the built site
+        # pa11y-ci needs a running server to crawl the built site.
+        # Chromium requires --no-sandbox on GitHub Actions runners (see .pa11yci).
         run: |
           npx serve _build/html -p 4117 &
           SERVER_PID=$!

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,5 +30,7 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+         external_repository: UC-OSPO-Network/UC-OSPO-Network.github.io
+          publish_branch: main
           publish_dir: _build/html
           cname: ucospo.net

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-         external_repository: UC-OSPO-Network/UC-OSPO-Network.github.io
+          external_repository: UC-OSPO-Network/UC-OSPO-Network.github.io
           publish_branch: main
           publish_dir: _build/html
           cname: ucospo.net

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,28 +25,7 @@ jobs:
           node-version: 20
           cache: npm
 
-      - run: npm ci
-
-      - run: npx myst build --html
-
-      - run: node scripts/generate-feed.js
-
-      - run: npx linkinator ./_build/html/
-
-      - name: Accessibility check
-        # pa11y-ci needs a running server to crawl the built site.
-        # Chromium requires --no-sandbox on GitHub Actions runners (see .pa11yci).
-        run: |
-          npx serve _build/html -p 4117 &
-          SERVER_PID=$!
-          # Ensure the server is killed even if pa11y-ci fails, so the
-          # background process doesn't linger until the job times out.
-          trap "kill $SERVER_PID" EXIT
-          # Wait for server to be ready (more reliable than a fixed sleep)
-          timeout 30 bash -c 'until curl -s http://localhost:4117 > /dev/null; do sleep 1; done'
-          npx pa11y-ci --sitemap http://localhost:4117/sitemap.xml \
-            --sitemap-find 'http://localhost:[0-9]+' \
-            --sitemap-replace 'http://localhost:4117'
+      - run: make check
 
       - uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Prevent parallel deploys if multiple commits are pushed to main in quick
+# succession. The last push wins; earlier runs are cancelled.
+concurrency:
+  group: deploy-pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx myst build --html
+
+      - run: node scripts/generate-feed.js
+
+      - run: npx linkinator ./_build/html/
+
+      - name: Accessibility check
+        # pa11y-ci needs a running server to crawl the built site
+        run: |
+          npx serve _build/html -p 4117 &
+          SERVER_PID=$!
+          # Ensure the server is killed even if pa11y-ci fails, so the
+          # background process doesn't linger until the job times out.
+          trap "kill $SERVER_PID" EXIT
+          # Wait for server to be ready (more reliable than a fixed sleep)
+          timeout 30 bash -c 'until curl -s http://localhost:4117 > /dev/null; do sleep 1; done'
+          npx pa11y-ci --sitemap http://localhost:4117/sitemap.xml \
+            --sitemap-find 'http://localhost:[0-9]+' \
+            --sitemap-replace 'http://localhost:4117'
+
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/html
+          cname: ucospo.net

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,62 @@
+name: PR Build Check & Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx myst build --html
+
+      - run: node scripts/generate-feed.js
+
+      - run: npx linkinator ./_build/html/
+
+      - name: Accessibility check
+        # pa11y-ci needs a running server to crawl the built site
+        run: |
+          npx serve _build/html -p 4117 &
+          SERVER_PID=$!
+          # Ensure the server is killed even if pa11y-ci fails, so the
+          # background process doesn't linger until the job times out.
+          trap "kill $SERVER_PID" EXIT
+          # Wait for server to be ready (more reliable than a fixed sleep)
+          timeout 30 bash -c 'until curl -s http://localhost:4117 > /dev/null; do sleep 1; done'
+          npx pa11y-ci --sitemap http://localhost:4117/sitemap.xml \
+            --sitemap-find 'http://localhost:[0-9]+' \
+            --sitemap-replace 'http://localhost:4117'
+
+      # continue-on-error because fork PRs don't have write access to push
+      # the preview to gh-pages. The build check above still validates the PR.
+      - uses: rossjrw/pr-preview-action@v1
+        continue-on-error: true
+        with:
+          source-dir: _build/html
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,27 +24,7 @@ jobs:
           node-version: 20
           cache: npm
 
-      - run: npm ci
-
-      - run: npx myst build --html
-
-      - run: node scripts/generate-feed.js
-
-      - run: npx linkinator ./_build/html/
-
-      - name: Accessibility check
-        # pa11y-ci needs a running server to crawl the built site
-        run: |
-          npx serve _build/html -p 4117 &
-          SERVER_PID=$!
-          # Ensure the server is killed even if pa11y-ci fails, so the
-          # background process doesn't linger until the job times out.
-          trap "kill $SERVER_PID" EXIT
-          # Wait for server to be ready (more reliable than a fixed sleep)
-          timeout 30 bash -c 'until curl -s http://localhost:4117 > /dev/null; do sleep 1; done'
-          npx pa11y-ci --sitemap http://localhost:4117/sitemap.xml \
-            --sitemap-find 'http://localhost:[0-9]+' \
-            --sitemap-replace 'http://localhost:4117'
+      - run: make check
 
       # continue-on-error because fork PRs don't have write access to push
       # the preview to gh-pages. The build check above still validates the PR.

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,6 +1,9 @@
 {
   "defaults": {
     "standard": "WCAG2AA",
-    "timeout": 15000
+    "timeout": 15000,
+    "chromeLaunchConfig": {
+      "args": ["--no-sandbox"]
+    }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,9 @@ Thank you for investing your time in contributing to our project!
   - Locally, as follows:
     - Install Node.js v20+ and run `npm install`
     - Run `make serve` (or `npx myst start`)
-  - Via Netlify's "deploy preview":
-    - Create a draft PR
-    - After Netlify finishes running its checks, click "Deploy Preview" in the comment created by the Netlify bot
+  - Via deploy preview (branch PRs only—not available for fork PRs):
+    - Open a PR from a branch in this repo
+    - After CI finishes, a comment will appear with a link to a preview of your changes
 - To check accessibility: run `npm run build` then `npm run check-a11y`. This uses [pa11y-ci](https://github.com/pa11y/pa11y-ci) to test every page against WCAG 2.1 AA.
 - To make sure your code passes linting and formatting checks, you can either:
   - Run `pre-commit run` before committing (or `pre-commit run --all-files` to check everything). This runs Prettier (formatting), markdownlint (structure and accessibility), Black (Python), and codespell (typos).
@@ -98,11 +98,15 @@ Here are some resources to help you get started with open source contributions:
 4.  Review process:
     - Every Pull Request (PR) update triggers a set of [continuous
       integration](https://en.wikipedia.org/wiki/Continuous_integration)
-      services that check that it is up to standards and passes
-      all our tests. These checks must pass before your PR can be
-      merged. If one of the checks fails, you can find out why by
-      clicking on the "failed" icon (red cross) and inspecting the
-      build and test log.
+      checks that must pass before your PR can be merged:
+      - **Build** — confirms the site builds successfully with MyST
+      - **Link check** — [linkinator](https://github.com/JustinBeckwith/linkinator) verifies all internal and external links
+      - **Accessibility** — [pa11y-ci](https://github.com/pa11y/pa11y-ci) tests every page against WCAG 2.1 AA
+      - **Linting/formatting** — pre-commit.ci checks Prettier, markdownlint, Black, and codespell
+
+      If a check fails, click the "failed" icon (red cross) to see the
+      build log and find out what needs fixing.
+
     - If the `pre-commit.ci` test fails, you can usually have the
       pre-commit bot push a fix to your branch by adding a comment on your
       PR with the text `pre-commit.ci autofix`.

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,37 @@
-.PHONY: help install html serve clean
+.PHONY: help install html serve clean lint a11y check
 .DEFAULT_GOAL := help
 
 help:
 	@grep ": ##" Makefile | grep -v grep | tr -d '#'
 
 install: ## Install Node dependencies (mystmd)
-	npm install
+	npm ci
 
 html: ## Build MyST site in ./_build/html
 html: install
-	npx myst build --html && node scripts/generate-feed.js
+	npx myst build --html
+	node scripts/generate-feed.js
 
 serve: ## Serve MyST site locally (live reload)
 serve: install
 	npx myst start
+
+lint: ## Check for broken links in the built site
+lint: html
+	npx linkinator ./_build/html/
+
+a11y: ## Run accessibility checks against the built site
+a11y: html
+	npx serve _build/html -p 4117 & \
+	SERVER_PID=$$!; \
+	trap "kill $$SERVER_PID" EXIT; \
+	timeout 30 bash -c 'until curl -s http://localhost:4117 > /dev/null; do sleep 1; done'; \
+	npx pa11y-ci --sitemap http://localhost:4117/sitemap.xml \
+		--sitemap-find 'http://localhost:[0-9]+' \
+		--sitemap-replace 'http://localhost:4117'
+
+check: ## Run full build + lint + accessibility (same as CI)
+check: lint a11y
 
 clean: ## Remove built files
 clean:

--- a/README.md
+++ b/README.md
@@ -85,8 +85,24 @@ This project uses [pre-commit](https://pre-commit.com) with:
 - **[Black](https://black.readthedocs.io)** — Python code formatting
 - **[codespell](https://github.com/codespell-project/codespell)** — catches common typos
 
-If you push without running pre-commit locally, the `pre-commit.ci` bot will check
-your PR automatically. See [CONTRIBUTING.md](CONTRIBUTING.md) for usage details.
+If you push without running pre-commit locally, the `pre-commit.ci` bot will check your PR automatically. See [CONTRIBUTING.md](CONTRIBUTING.md) for usage details.
+
+## CI and deployment
+
+The site is deployed to [GitHub Pages](https://pages.github.com) via GitHub Actions.
+
+**On push to `main`:** the site is built, checked (linkinator + pa11y-ci), and deployed to the `gh-pages` branch.
+
+**On pull requests:** the same build and checks run. Branch PRs also get a deploy preview at `ucospo.net/pr-preview/pr-<number>/` (fork PRs get the build check but not the preview).
+
+CI checks that run on every PR:
+
+| Check              | Tool                                                       | What it catches                                   |
+| ------------------ | ---------------------------------------------------------- | ------------------------------------------------- |
+| Build              | MyST                                                       | Broken Markdown, missing files, config errors     |
+| Links              | [linkinator](https://github.com/JustinBeckwith/linkinator) | Broken internal and external links                |
+| Accessibility      | [pa11y-ci](https://github.com/pa11y/pa11y-ci)              | WCAG 2.1 AA violations (contrast, alt text, etc.) |
+| Linting/formatting | [pre-commit.ci](https://pre-commit.ci)                     | Formatting, Markdown structure, typos             |
 
 ## Contributing
 


### PR DESCRIPTION
We're switching from Netlify to GitHub Pages for deploying the website, partly because Netlify is overkill for our use case and also so that we can have more than one person do more of the site admin without having to find a way to securely share credentials.

NB: Ive added a GitHub Action to do deploy previews similar to Netlify's, but it can't make previews for forks. I'll need to make sure people like @virginiascarlett get privileges that don't require forking.

I've also added linkinator (checks for broken links) and pa11y (accessibility auditor) to the build test. I'd previously added them as dependencies, but realized today that it's still possible to push changes without running them so now that leak is plugged. The `README` is updated accordingly.