### PR TITLE
Fix formatting in day 1 schedule formatting

### DIFF
--- a/events/uc-open-2026/index.md
+++ b/events/uc-open-2026/index.md
@@ -123,26 +123,22 @@ _Thanks to the generosity of our sponsors, UC Open is **free to attend** for all
   - Break & Networking
 * - 11:00–11:50
   - **Panel: Understanding Open Source Pathways—A Review of NSF POSE Funded Projects across the UC System**
-
-Chaired by Amber Budden (UCSB)\
-Panelists: Jarrod Millman (UC Berkeley), Harikrishna Kuttivelil (UCSC), Andrew Kahng (UCSD), Stephanie Lieggi (UCSC), Sanjit Seshia (UC Berkeley)
+    Chaired by Amber Budden (UCSB).
+    Panelists: Jarrod Millman (UC Berkeley), Harikrishna Kuttivelil (UCSC), Andrew Kahng (UCSD), Stephanie Lieggi (UCSC), Sanjit Seshia (UC Berkeley)
 * - 11:50–12:30
   - **Keynote:** Nithya Ruff (Linux Foundation)—*[The Role of Foundations In Advancing Open Collaboration and Innovation](./talks/role-of-foundations-in-open-source.md)*
 * - 12:30–2:00
   - Lunch & Networking
-
     *Poster Session (1:00–2:00)*
 * - 2:00–3:45
   - **Breakout 1: Open Practices for Education and Training**
-
     - 2:00–2:15 *[UC OSPO Education Activities](./talks/uc-ospo-education-activities.md)*—Tim Dennis (UCLA)
     - 2:15–2:30 *[From Deployment to Ecosystem: Building Sustainable JupyterHub Infrastructure for Research and Teaching](./talks/sustainable-jupyterhub-infrastructure.md)*—Shane Knapp & Eric Van Dusen (UC Berkeley)
     - 2:30–2:45 *[Open Practices for Education and Training](./talks/open-practices-for-education-and-training.md)*—Emily Lovell (UCSC)
     - 2:45–3:00 *[Open Source Adaptive Tutoring for UC STEM](./talks/open-source-adaptive-tutoring-for-uc-stem.md)*—Ioannis Anastasopoulos & Zachary Pardos (UC Berkeley)
     - 3:00–3:45 *Facilitated Discussion moderated by Laura Langdon (UC OSPO Network)*
 
-    **Breakout 2: Open Source Tools for Scientific Research**
-
+  **Breakout 2: Open Source Tools for Scientific Research**
     - 2:00–2:15 *[Unmapped Cities: Scaling Pedestrian Infrastructure Mapping with Tile2Net](./talks/unmapped-cities.md)*—Maryam Hosseini (UC Berkeley)
     - 2:15–2:30 *[Jupyter Book: Next-generation Tools for Creating Computational Narratives](./talks/jupyter-book-next-gen-tools.md)*—Chris Holdgraf (2i2c)
     - 2:30–2:45 *[From Silos to Standards: Open Data Modeling with LinkML](./talks/from-silos-to-standards-linkml.md)*—Nomi Harris (LBNL)
@@ -152,8 +148,7 @@ Panelists: Jarrod Millman (UC Berkeley), Harikrishna Kuttivelil (UCSC), Andrew K
   - Break & Networking
 * - 4:00–4:45
   - **Panel:** [Open Source Commercialization and Impact](./talks/open-source-commercialization-and-impact.md)
-
-    Chaired by Karla Padilla (UCSD)\
+    Chaired by Karla Padilla (UCSD).
     Panelists: Heather Meeker (Chinstrap Community), Mike Cohen (UC Berkeley), Dirk Riehle (FAU Erlangen-Nürnberg), Joel Kehle (UCLA)
 * - 4:45–5:15
   - **[Lightning Intros](./talks/lightning-intros.md)**
@@ -171,31 +166,26 @@ Panelists: Jarrod Millman (UC Berkeley), Harikrishna Kuttivelil (UCSC), Andrew K
   - **Opening Session—OSPO Network Update**
 * - 10:00–10:50
   - **Panel: Influence of AI on Open Source and Open Scholarship**
-
     Panelists: Fernando Perez (UC Berkeley), Sahiba Chopra (UC Berkeley), Marit MacArthur (UC Davis), Tara Hernandez (MongoDB/UCSC)
 * - 10:50–11:10
   - Break & Networking
 * - 11:10–12:25
   - **Breakout 1: Enabling Impact Across California**
-
     - 11:10–11:25 *[Hidden in Plain Sight: Discovering the University of California Open Source Landscape](./talks/hidden-in-plain-sight-uc-open-source-landscape.md)*—Juanita Gomez (UCSC)
     - 11:25–11:40 *[More Than Just Storage: Support for Open Scholarship through Campus Collaborations](./talks/more-than-just-storage.md)*—Sam Teplitzky & Anna Sackmann (UC Berkeley)
     - 11:40–11:55 *[A Funder's Perspective on Promoting Best Practices in Data Sharing and Management](./talks/best-practices-data-sharing-and-management.md)*—Alden Conner (CIRM)
     - 12:00–12:25 *Facilitated Discussion moderated by Renea Davis-Leathers (UCOP)*
 
     **Breakout 2: Building Open Source and Open Science Ecosystems**
-
     - 11:10–11:25 *[The OCUDU Blueprint: A New Paradigm for Collaboration in Open Source Innovation](./talks/ocudu-blueprint.md)*—Ranny Haiby (Linux Foundation)
     - 11:25–11:40 *[Open Science Assistant (OSA): An Easy-to-Onboard AI Chatbot for Open Source Research Projects](./talks/open-science-assistant.md)*—Seyed Yahya Shirazi (UCSD)
     - 11:40–11:55 *[Using Continuous Integration to Ensure Accessible Experiences](./talks/continuous-integration-accessible-experiences.md)*—Michael Ball & Silas Santini (UC Berkeley)
     - 12:00–12:25 *Facilitated Discussion*
 * - 12:25–1:45
   - Lunch & Networking
-
     *Poster Session (1:00–1:45)*
 * - 1:45–3:15
   - **Breakout 1: Open Source Tools for Public Benefit**
-
     - 1:45–2:00 *[An Open-Source Ecosystem for Building Weather Driven Agricultural Decision Tools](./talks/weather-driven-agricultural-decision-tools.md)*—Andy Lyons (UC ANR)
     - 2:00–2:15 *TBA*
     - 2:15–2:30 *[Building Tools for Police Accountability](./talks/building-tools-for-police-accountability.md)*—Tarak Shah (UC Berkeley / BIDS)
@@ -203,7 +193,6 @@ Panelists: Jarrod Millman (UC Berkeley), Harikrishna Kuttivelil (UCSC), Andrew K
     - 2:50–3:15 *Facilitated Discussion moderated by Virginia Scarlett (UCSB)*
 
     **Breakout 2: Open Infrastructure for Collaborative Research**
-
     - 1:45–2:00 *[Making Jupyter Notebooks Accessible](./talks/making-jupyter-notebooks-accessible.md)*—Balaji Alwar & Chanbin Park (UC Berkeley)
     - 2:00–2:15 *[PeerSky in Academia: Create, Publish, and Share Research Without the Cloud](./talks/peersky-in-academia.md)*—Akhilesh Thite (UCSC)
     - 2:15–2:30 *[TRACE: Open Provenance Infrastructure for AI-Assisted Research](./talks/who-did-the-thinking.md)*—Oliver Muellerklein (UC Berkeley)

--- a/events/uc-open-2026/index.md
+++ b/events/uc-open-2026/index.md
@@ -138,7 +138,7 @@ _Thanks to the generosity of our sponsors, UC Open is **free to attend** for all
     - 2:45–3:00 *[Open Source Adaptive Tutoring for UC STEM](./talks/open-source-adaptive-tutoring-for-uc-stem.md)*—Ioannis Anastasopoulos & Zachary Pardos (UC Berkeley)
     - 3:00–3:45 *Facilitated Discussion moderated by Laura Langdon (UC OSPO Network)*
 
-  **Breakout 2: Open Source Tools for Scientific Research**
+    **Breakout 2: Open Source Tools for Scientific Research**
     - 2:00–2:15 *[Unmapped Cities: Scaling Pedestrian Infrastructure Mapping with Tile2Net](./talks/unmapped-cities.md)*—Maryam Hosseini (UC Berkeley)
     - 2:15–2:30 *[Jupyter Book: Next-generation Tools for Creating Computational Narratives](./talks/jupyter-book-next-gen-tools.md)*—Chris Holdgraf (2i2c)
     - 2:30–2:45 *[From Silos to Standards: Open Data Modeling with LinkML](./talks/from-silos-to-standards-linkml.md)*—Nomi Harris (LBNL)


### PR DESCRIPTION
As of 10am 15 April the schedule for day 1 isn't showing on the live website.

I think its because of a few `\` characters... this PR is a space for me to experiment to see what I can do to fix it!