### PR TITLE
treat 403 as warning instead of error in link checker

### DIFF
--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -8,5 +8,8 @@
     "lists.ucdavis.edu",
     "travel.ucop.edu",
     "github.com/.*/edit/"
+  ],
+  "statusCode": [
+    "403:warn"
   ]
 }


### PR DESCRIPTION
The CI failure on #305 is from linkinator getting a 403 on our Slack invite link. The link itself is fine and doesn't expire until 2030. Instead, Slack appears to have recently tightened bot protection for invite URLs coming from CI runners. The same link returns 302 (normal redirect) from a regular machine but 403 from CI runners. I checked the logs—the exact same link returned 200 on every CI run through April 22, then started returning 403 on April 28. Same linkinator version, same config, same link. Nothing changed on our side.

Rather than skipping Slack links entirely (we want to know if an invite link actually expires), this treats all 403s as warnings instead of errors. A 403 will still show up in the build logs, but it won't block PRs. If a link genuinely dies, it'll return 404 or redirect, which will still fail the build.