### PR TITLE
Add contact page with campus contacts and mailing lists

### DIFF
--- a/about/about.md
+++ b/about/about.md
@@ -44,7 +44,4 @@ Whether you're an individual looking to participate or an institution interested
 
 ## Contact Us
 
-- **Laura Langdon**, Community Manager: [lalangdon@ucdavis.edu](mailto:lalangdon@ucdavis.edu) (not sure who to talk to? Talk to Laura!)
-- **Stephanie Lieggi**, Network Chair: [slieggi@ucsc.edu](mailto:slieggi@ucsc.edu)
-
-For campus-specific contacts and mailing lists, see [Get Involved](get-involved.md).
+Not sure who to talk to? See our [Contact page](contact.md) for network and campus-specific contacts.

--- a/about/contact.md
+++ b/about/contact.md
@@ -1,0 +1,27 @@
+---
+title: Contact Us
+---
+
+Not sure who to talk to? Start with [Laura Langdon](mailto:lalangdon@ucdavis.edu), our Community Manager. Laura is the network's generalist—if you have a question about open source at the UC and don't know where to send it, she'll point you in the right direction.
+
+[Stephanie Lieggi](mailto:slieggi@ucsc.edu), the Network Chair, leads the UC OSPO Network from UC Santa Cruz and oversees the network's strategy, funding, and partnerships.
+
+## Campus contacts
+
+If you know which campus you're looking for, connect directly:
+
+- **Berkeley**—[Jarrod Millman](mailto:millman@berkeley.edu) & [Kirstie Whitaker](mailto:kirstie.whitaker@berkeley.edu) · [join mailing list](mailto:ospo+subscribe@lists.berkeley.edu)
+- **Davis**—[Vessela Ensberg](mailto:vensberg@ucdavis.edu) · [join mailing list](https://lists.ucdavis.edu/sympa/info/opensource-announce)
+- **Los Angeles**—[Tim Dennis](mailto:timdennis@ucla.edu) & [Leigh Phan](mailto:leighphan@library.ucla.edu) · [join mailing list](https://groups.google.com/g/ucla-ospo)
+- **San Diego**—[David Minor](mailto:dminor@ucsd.edu) & [Karla Padilla](mailto:kapadilla@ucsd.edu)
+- **Santa Barbara**—[Amber Budden](mailto:ospo@library.ucsb.edu) & [Virginia Scarlett](mailto:virginiascarlett@ucsb.edu) · [join mailing list](https://lp.constantcontactpages.com/sl/hlmtgmY/ucsbospo)
+- **Santa Cruz**—[Stephanie Lieggi](mailto:slieggi@ucsc.edu) & [Emily Lovell](mailto:elovell@ucsc.edu) · [join mailing list](https://groups.google.com/u/0/a/ucsc.edu/g/ucsc-open-source-news-group/about)
+
+If you don't see your institution listed, you're still welcome! [Reach out to Laura](mailto:lalangdon@ucdavis.edu) and she'll help you get connected.
+
+## Other ways to connect
+
+- [Join the UC OSPO Network Slack](https://join.slack.com/t/uc-ospo-network/shared_invite/zt-3ecp5b20z-ECL~4DkCUslB0t3mbH9xUg)
+- [Subscribe to the network newsletter](https://mailchi.mp/ucdavis/uc-ospo-network)
+- [See upcoming events](../events/index.md)
+- [Get involved](get-involved.md)

--- a/about/get-involved.md
+++ b/about/get-involved.md
@@ -20,16 +20,7 @@ No matter how you're joining the community—as an individual or as a new instit
 
 There's no minimum attendance requirement. Come to what interests you, when you can.
 
-If your campus has an OSPO or a presence in the network, connect with your local contact:
-
-- **Berkeley**—[Jarrod Millman](mailto:millman@berkeley.edu) · [join mailing list](mailto:ospo+subscribe@lists.berkeley.edu)
-- **Davis**—[davis-ospo@ucdavis.edu](mailto:davis-ospo@ucdavis.edu) · [join mailing list](https://lists.ucdavis.edu/sympa/info/opensource-announce)
-- **Los Angeles**—[Tim Dennis](mailto:tdennis@library.ucla.edu) · [join mailing list](https://groups.google.com/g/ucla-ospo)
-- **San Diego**—[David Minor](mailto:dminor@ucsd.edu)
-- **Santa Barbara**—[Amber Budden](mailto:ospo@library.ucsb.edu) · [join mailing list](https://lp.constantcontactpages.com/sl/hlmtgmY/ucsbospo)
-- **Santa Cruz**—[Stephanie Lieggi](mailto:ospo-info-group@ucsc.edu) · [join mailing list](https://groups.google.com/u/0/a/ucsc.edu/g/ucsc-open-source-news-group/about)
-
-If you don't see your campus listed, you're still welcome! Join the Slack workspace and the [network newsletter](https://mailchi.mp/ucdavis/uc-ospo-network), and/or [reach out to Laura](mailto:lalangdon@ucdavis.edu) and she'll point you in the right direction.
+See our [Contact page](contact.md) for campus-specific contacts and mailing lists.
 
 ---
 

--- a/footer.md
+++ b/footer.md
@@ -1,25 +1,42 @@
 % Site footer — referenced from myst.yml site.parts.footer
 
-:::::{grid} 1 1 2 2
+:::::{div}
 :class: uco-footer col-screen
 
 ::::{div}
+:class: uco-footer-row
+
+:::{div}
 :class: uco-footer-brand
-:::{image} static/images/uc-ospo-network-logo.svg
+
+```{image} static/images/uc-ospo-network-logo.svg
 :alt: UC OSPO Network
 :class: uco-logo-dark
-:::
-:::{image} static/images/uc-ospo-network-logo-light.svg
+```
+
+```{image} static/images/uc-ospo-network-logo-light.svg
 :alt: UC OSPO Network
 :class: uco-logo-light
-:::
-::::
+```
 
-::::{div}
+:::
+
+:::{div}
+:class: uco-footer-nav
+[About](about/about.md)
+[Events](events/index.md)
+[Blog](posts/index.md)
+[Resources](oss-resources/index.md)
+[Contact](about/contact.md)
+:::
+
+:::{div}
 :class: uco-footer-social
-[![UC OSPO Network on GitHub](static/images/icons/github.svg)](https://github.com/UC-OSPO-Network/)
-[![UC OSPO Network on Slack](static/images/icons/slack.svg)](https://join.slack.com/t/uc-ospo-network/shared_invite/zt-3ecp5b20z-ECL~4DkCUslB0t3mbH9xUg)
-[![RSS feed](static/images/icons/rss.svg)](/atom.xml)
+[![GitHub](static/images/icons/github.svg)](https://github.com/UC-OSPO-Network/)
+[![Slack](static/images/icons/slack.svg)](https://join.slack.com/t/uc-ospo-network/shared_invite/zt-3ecp5b20z-ECL~4DkCUslB0t3mbH9xUg)
+[![RSS](static/images/icons/rss.svg)](/atom.xml)
+:::
+
 ::::
 
 :::::

--- a/index.md
+++ b/index.md
@@ -17,6 +17,6 @@ Welcome to the **University of California Open Source Program Office Network**!
 The UC OSPO Network is a groundbreaking initiative that harnesses the collective power of six UC campuses to revolutionize open-source practices in academia.
 This collaborative effort aims to amplify the impact of research, public service, and education across the University of California system.
 
-Join us in shaping the future of open-source in academia and beyond.
+Join us in shaping the future of open-source in academia and beyond. [Get in touch →](about/contact.md)
 ::::
 :::::

--- a/myst.yml
+++ b/myst.yml
@@ -11,6 +11,7 @@ project:
         - file: about/about.md
         - file: about/services.md
         - file: about/get-involved.md
+        - file: about/contact.md
         - file: about/guiding-themes/index.md
           children:
             - file: about/guiding-themes/discovery.md

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -310,7 +310,7 @@ footer.article-grid {
 .uco-footer-brand img {
   height: auto;
   width: 100%;
-  max-width: 360px;
+  max-width: 240px;
   margin-left: 0 !important;
   margin-right: auto !important;
 }
@@ -371,6 +371,42 @@ footer.article-grid {
 [data-theme="dark"] .uco-footer-social img,
 .dark .uco-footer-social img {
   filter: invert(1);
+}
+
+/* ── Footer row layout (logo | nav | social) ──────────────────── */
+
+.uco-footer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+}
+
+.uco-footer-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
+
+.uco-footer-nav p {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  margin: 0;
+}
+
+.uco-footer-nav a {
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.7;
+}
+
+.uco-footer-nav a:hover {
+  opacity: 1;
 }
 
 /* ── Register button ──────────────────────────────────────────── */

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -409,6 +409,25 @@ footer.article-grid {
   opacity: 1;
 }
 
+@media (max-width: 768px) {
+  .uco-footer-row {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  .uco-footer-nav p {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem 1.25rem;
+  }
+
+  .uco-footer-social {
+    justify-content: center !important;
+    padding-right: 0 !important;
+  }
+}
+
 /* ── Register button ──────────────────────────────────────────── */
 
 .register-btn a {


### PR DESCRIPTION
Previously our contact info was duplicated across several pages and hard to keep in sync. Now there's a dedicated contact page that can be referred to from other pages, and linked in the footer. I also added some other links to the footer for ease of access.