### PR TITLE
remove trailing div fence from a button

### DIFF
--- a/santa-barbara/ucsb-projects/meetup.md
+++ b/santa-barbara/ucsb-projects/meetup.md
@@ -44,9 +44,9 @@ can get done in just half an hour.
 ### Upcoming meetings:
 
 ::::{div} :class: btn-center-wrapper
-
 <a href="https://docs.google.com/spreadsheets/d/19SdbFZwA4JrZBf5GsVqIYkOeVkieI-xvy2NJnR7kFeE/edit?usp=sharing" class="btn-ucsb-primary">Sign
-up to lead a meeting here!</a> ::::
+up to lead a meeting here!</a>
+::::
 
 | Date         | Time     | Topic                                                                                                          | Link                                                                     | Other notes                                |
 | ------------ | -------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------ |


### PR DESCRIPTION
World's tiniest PR. Prettier moves the div fences to the end of the last line, since it doesn't like punctuation being on its own line. There are more systematic changes I could make to prevent this, and also to re-align this button, but those will take time I don't have, so for now I'd prefer to just remove the '::::' from the live web page and call it a day.