### PR TITLE
update mailing list link for ucsb on about page

### DIFF
--- a/about/contact.md
+++ b/about/contact.md
@@ -14,7 +14,7 @@ If you know which campus you're looking for, connect directly:
 - **Davis**—[Vessela Ensberg](mailto:vensberg@ucdavis.edu) · [join mailing list](https://lists.ucdavis.edu/sympa/info/opensource-announce)
 - **Los Angeles**—[Tim Dennis](mailto:timdennis@ucla.edu) & [Leigh Phan](mailto:leighphan@library.ucla.edu) · [join mailing list](https://groups.google.com/g/ucla-ospo)
 - **San Diego**—[David Minor](mailto:dminor@ucsd.edu) & [Karla Padilla](mailto:kapadilla@ucsd.edu)
-- **Santa Barbara**—[Amber Budden](mailto:ospo@library.ucsb.edu) & [Virginia Scarlett](mailto:virginiascarlett@ucsb.edu) · [join mailing list](https://lp.constantcontactpages.com/sl/hlmtgmY/ucsbospo)
+- **Santa Barbara**—[Amber Budden](mailto:ospo@library.ucsb.edu) & [Virginia Scarlett](mailto:virginiascarlett@ucsb.edu) · [join mailing list](https://signup.e2ma.net/signup/2045162/1984731/)
 - **Santa Cruz**—[Stephanie Lieggi](mailto:slieggi@ucsc.edu) & [Emily Lovell](mailto:elovell@ucsc.edu) · [join mailing list](https://groups.google.com/u/0/a/ucsc.edu/g/ucsc-open-source-news-group/about)
 
 If you don't see your institution listed, you're still welcome! [Reach out to Laura](mailto:lalangdon@ucdavis.edu) and she'll help you get connected.


### PR DESCRIPTION
Runner-up for the world's tiniest PR. Update the link to our mailing list on the about page, since UCSB has switched from Constant Contact to Emma.