### PR TITLE
Add abs paths to site yml

### DIFF
--- a/footer.md
+++ b/footer.md
@@ -1,4 +1,4 @@
-% Site footer — referenced from myst.yml site.parts.footer
+% Site footer — referenced from site.yml
 
 :::::{div}
 :class: uco-footer col-screen
@@ -9,12 +9,12 @@
 :::{div}
 :class: uco-footer-brand
 
-```{image} static/images/uc-ospo-network-logo.svg
+```{image} https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/images/logo.svg
 :alt: UC OSPO Network
 :class: uco-logo-dark
 ```
 
-```{image} static/images/uc-ospo-network-logo-light.svg
+```{image} https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/images/uc-ospo-network-logo-light.svg
 :alt: UC OSPO Network
 :class: uco-logo-light
 ```
@@ -23,18 +23,18 @@
 
 :::{div}
 :class: uco-footer-nav
-[About](about/about.md)
-[Events](events/index.md)
-[Blog](posts/index.md)
-[Resources](oss-resources/index.md)
-[Contact](about/contact.md)
+[About](https://ucospo.net/about/about/)
+[Events](https://ucospo.net/events/)
+[Blog](https://ucospo.net/posts/)
+[Resources](https://ucospo.net/oss-resources/)
+[Contact](https://ucospo.net/about/contact/)
 :::
 
 :::{div}
 :class: uco-footer-social
-[![GitHub](static/images/icons/github.svg)](https://github.com/UC-OSPO-Network/)
-[![Slack](static/images/icons/slack.svg)](https://join.slack.com/t/uc-ospo-network/shared_invite/zt-3ecp5b20z-ECL~4DkCUslB0t3mbH9xUg)
-[![RSS](static/images/icons/rss.svg)](/atom.xml)
+[![GitHub](https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/images/icons/github.svg)](https://github.com/UC-OSPO-Network/)
+[![Slack](https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/images/icons/slack.svg)](https://join.slack.com/t/uc-ospo-network/shared_invite/zt-3ecp5b20z-ECL~4DkCUslB0t3mbH9xUg)
+[![RSS](https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/images/icons/rss.svg)](/atom.xml)
 :::
 
 ::::

--- a/site.yml
+++ b/site.yml
@@ -8,6 +8,7 @@ site:
     style: https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/css/custom.css
     logo_text: "UC OSPO Network"
     hide_footer_links: true
+    internal_domains: ucospo.net
   template: book-theme
   parts:
-    footer: https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/footer.md
+    footer: footer.md

--- a/site.yml
+++ b/site.yml
@@ -2,12 +2,12 @@ version: 1
 site:
   options:
     lang: en
-    logo: static/images/logo.svg
-    favicon: static/images/favicon.ico
+    logo: https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/images/logo.svg
+    favicon: https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/images/favicon.ico
     folders: true
-    style: static/css/custom.css
+    style: https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/css/custom.css
     logo_text: "UC OSPO Network"
     hide_footer_links: true
   template: book-theme
   parts:
-    footer: footer.md
+    footer: https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/footer.md

--- a/site.yml
+++ b/site.yml
@@ -1,3 +1,6 @@
+# Use absolute paths instead of relative paths so that sub-projects
+# using the 'extends' key can find static assets.
+# https://jupyterbook.org/blog/posts/2026/multi-repo
 version: 1
 site:
   options:


### PR DESCRIPTION
I'm, like, pretty sure this PR won't break the website.

I've swapped the relative paths in site.yml and footer.md for absolute paths. This allows the playbook repo (and perhaps, someday, other subprojects) that are inheriting stuff through MyST's "extends" functionality to find the assets mentioned in those files.

The only path I kept as a relative path is footer.md. I'll change that later, in a separate PR, for convoluted reasons. (Basically, because the absolute path contains the branch name, if I put main/footer.md in this PR, we won't actually get to see whether my modified footer file works because it will be pointing to the one that's currently live, not the one here.)

This is all copied from the workflow described in the [JupyterBook blog here](https://jupyterbook.org/blog/posts/2026/multi-repo). I'm basing this new site.yml file on [the site.yml file](https://github.com/jupyter-book/jupyterbook.org/blob/main/docs/_site/site.yml) from their "core repo" (the one subprojects inherit from).

I added the "internal_domains" key (like they did) to indicate that links from ucospo.net should be treated as internal, and should not open a new tab or have this little symbol next to them: 
<img width="56" height="29" alt="image" src="https://github.com/user-attachments/assets/f7533357-7313-4a64-8a88-a044a53d36c0" />
Without this, both the playbook and the core site will treat the "ABOUT", "EVENTS", "BLOG", etc. links in the footer as external links.

The pro of this is, as I said earlier, it allows for inheritance. The major con is that if you are a developer deploying a local preview, you might be surprised to find that if you click, e.g., "EVENTS" in the footer, you'll find yourself on ucospo.net/events instead of localhost:nnnn/events. JupyterBook also has this problem and as far as I can tell they just live with it.

Please double-check that I am not breaking the website. Try clicking all the stuff in the footer, especially the RSS feed link. It looks okay to me but I have no idea how that works.

Also let me know if you hate this, lol. To me, it seems more elegant than maintaining duplicate code and images in two repos, but I can see the case for ditching this inheritance thing, since it is a little more complicated.