### PR TITLE
Events aggregator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  # Rebuild on a schedule so the aggregated event feeds (built by `make html`)
+  # stay current with upstream campus calendars even when no one pushes for a
+  # while.
+  schedule:
+    - cron: "0 */12 * * *" # every 12h
   workflow_dispatch:
 
 permissions:
@@ -19,6 +24,7 @@ jobs:
     # Do not attempt to deploy documentation on forks
     if: github.repository_owner == 'UC-OSPO-Network'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,12 @@ jobs:
   build-and-check:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    env:
+      # Puppeteer's npm-ci postinstall download lands only partially on the
+      # runner (folder without binary), which breaks pa11y. Skip the implicit
+      # download in every `npm ci` (including the one inside `make check`) and
+      # install Chrome once, cleanly, in the explicit step below.
+      PUPPETEER_SKIP_DOWNLOAD: "true"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,4 +24,9 @@ jobs:
           node-version: 24
           cache: npm
 
+      - run: npm ci
+
+      - name: Install Chrome for Puppeteer (pa11y a11y checks)
+        run: npx puppeteer browsers install chrome
+
       - run: make check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,12 +16,6 @@ jobs:
   build-and-check:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
-    env:
-      # Puppeteer's npm-ci postinstall download lands only partially on the
-      # runner (folder without binary), which breaks pa11y. Skip the implicit
-      # download in every `npm ci` (including the one inside `make check`) and
-      # install Chrome once, cleanly, in the explicit step below.
-      PUPPETEER_SKIP_DOWNLOAD: "true"
     steps:
       - uses: actions/checkout@v4
 
@@ -30,9 +24,19 @@ jobs:
           node-version: 24
           cache: npm
 
+      # Skip Puppeteer's postinstall download here: on this runner it lands only
+      # partially (folder without binary), which breaks pa11y. Chrome is installed
+      # cleanly in the next step. (The skip flag must NOT be set on that step, or
+      # it muzzles the explicit install too.)
       - run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
 
       - name: Install Chrome for Puppeteer (pa11y a11y checks)
         run: npx puppeteer browsers install chrome
 
+      # `make check` runs `npm ci` again internally; skip its Puppeteer download
+      # too so it doesn't re-create the partial folder over the clean install.
       - run: make check
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,19 +24,21 @@ jobs:
           node-version: 24
           cache: npm
 
-      # Skip Puppeteer's postinstall download here: on this runner it lands only
-      # partially (folder without binary), which breaks pa11y. Chrome is installed
-      # cleanly in the next step. (The skip flag must NOT be set on that step, or
-      # it muzzles the explicit install too.)
+      # Puppeteer's own Chrome download is unreliable on the runner (it lands only
+      # partially, or the install no-ops), so skip it everywhere...
       - run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: "true"
 
-      - name: Install Chrome for Puppeteer (pa11y a11y checks)
-        run: npx puppeteer browsers install chrome
+      # ...and point pa11y/Puppeteer at the Chrome the ubuntu image already ships.
+      - name: Point Puppeteer at the runner's system Chrome
+        run: |
+          CHROME="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium-browser || true)"
+          echo "Using Chrome at: ${CHROME:-<none found>}"
+          test -n "$CHROME"
+          "$CHROME" --version
+          echo "PUPPETEER_EXECUTABLE_PATH=$CHROME" >> "$GITHUB_ENV"
 
-      # `make check` runs `npm ci` again internally; skip its Puppeteer download
-      # too so it doesn't re-create the partial folder over the clean install.
       - run: make check
         env:
           PUPPETEER_SKIP_DOWNLOAD: "true"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: make check

--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -1,0 +1,27 @@
+name: Validate event sources
+
+# Source-health alert for the campus event aggregator. Runs on a schedule and
+# fails loudly (red run + GitHub notification) if any campus feed breaks, so a
+# campus can't silently drop off the calendar.
+#
+# This does NOT deploy anything. Refreshing the live feeds is handled by the
+# scheduled run in deploy.yml (which rebuilds and redeploys to GitHub Pages).
+
+on:
+  schedule:
+    - cron: "0 */12 * * *" # every 12h
+  workflow_dispatch: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci
+      # Exits non-zero (failing the run) if any source errors.
+      - run: npm run validate-events

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install html serve clean lint a11y check
+.PHONY: help install html serve clean lint a11y test check
 .DEFAULT_GOAL := help
 
 help:
@@ -11,6 +11,7 @@ html: ## Build MyST site in ./_build/html
 html: install
 	npx myst build --html
 	node scripts/generate-feed.js
+	node scripts/aggregate-events.js
 
 serve: ## Serve MyST site locally (live reload)
 serve: install
@@ -18,8 +19,15 @@ serve: install
 
 lint: ## Check for broken links in the built site
 lint: html
-	npx linkinator ./_build/html/
+	npx linkinator ./_build/html/ --skip /events-embed.html
 
+# Accessibility. The embed (/events-embed.html) is not in the sitemap, so it is
+# audited separately below with `pa11y`. The --ignore'd codes are
+# FullCalendar-internal ARIA issues in its table markup that we cannot fix
+# without patching the library (fullcalendar/fullcalendar #7707, #7568, #6526).
+# Ignoring them is safe: the calendar was manually verified to be
+# keyboard-operable (Tab to an event, Enter opens its details popover), so the
+# ignores do not mask a real keyboard barrier.
 a11y: ## Run accessibility checks against the built site
 a11y: html
 	npx serve _build/html -p 4117 & \
@@ -28,10 +36,19 @@ a11y: html
 	timeout 30 bash -c 'until curl -s http://localhost:4117 > /dev/null; do sleep 1; done'; \
 	npx pa11y-ci --sitemap http://localhost:4117/sitemap.xml \
 		--sitemap-find 'http://localhost:[0-9]+' \
-		--sitemap-replace 'http://localhost:4117'
+		--sitemap-replace 'http://localhost:4117' && \
+	npx pa11y --standard WCAG2AA \
+		--ignore "WCAG2AA.Principle1.Guideline1_3.1_3_1.F92,ARIA4" \
+		--ignore "aria-prohibited-attr" \
+		--ignore "role-img-alt" \
+		http://localhost:4117/events-embed.html
 
-check: ## Run full build + lint + accessibility (same as CI)
-check: lint a11y
+test: ## Run unit tests (no build needed)
+test: install
+	npm test
+
+check: ## Run unit tests + full build + lint + accessibility (same as CI)
+check: test lint a11y
 
 clean: ## Remove built files
 clean:

--- a/events/index.md
+++ b/events/index.md
@@ -10,7 +10,6 @@ title: Events
 
 Add UC OSPO events to your own calendar app (Google, Apple, Outlook). Subscribe to as many feeds as you like:
 
-- [**All UC OSPO events**](https://ucospo.net/feeds/uc-ospo-all.ics) (everything below, in one feed)
 - [**Network-wide events**](https://ucospo.net/feeds/network.ics) (all-campus meetups and network-level events)
 - By campus:
   - [**UC Davis**](https://ucospo.net/feeds/davis.ics)

--- a/events/index.md
+++ b/events/index.md
@@ -4,11 +4,20 @@ title: Events
 
 ## Calendar
 
-<iframe title="UC OSPO Network event calendar" src="https://teamup.com/ksm2uwujdk3osj73h9?tz=Calendar%20default&showProfileAndInfo=0&showSidepanel=1&showViewHeader=1&showAgendaDetails=0&showDateControls=1&showDateRange=1" style="width: 100%; height: 800px; border: 1px solid #cccccc" loading="lazy" frameborder="0"></iframe>
+<iframe title="UC OSPO Network event calendar" src="/events-embed.html?v=6" loading="lazy"></iframe>
 
-:::{tip}
-Please note: if you add an event from the embedded calendar above, it will default to "Does not repeat". If you'd like to add all instances of a recurring event, please use the .ics file or the "Add to your Google calendar" button for the event below.
-:::
+## Subscribe
+
+Add UC OSPO events to your own calendar app (Google, Apple, Outlook). Subscribe to as many feeds as you like:
+
+- [**All UC OSPO events**](https://ucospo.net/feeds/uc-ospo-all.ics) (everything below, in one feed)
+- [**Network-wide events**](https://ucospo.net/feeds/network.ics) (all-campus meetups and network-level events)
+- By campus:
+  - [**UC Davis**](https://ucospo.net/feeds/davis.ics)
+  - [**UC Santa Barbara**](https://ucospo.net/feeds/ucsb.ics)
+  - [**UC Berkeley**](https://ucospo.net/feeds/berkeley.ics)
+  - [**UC San Diego**](https://ucospo.net/feeds/ucsd.ics)
+  - [**UC Santa Cruz**](https://ucospo.net/feeds/ucsc.ics)
 
 ## Upcoming Events
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 
 [build]
   publish = "_build/html"
-  command = "npm ci && npx myst build --html && node scripts/generate-feed.js && npx linkinator ./_build/html/"
+  command = "npm ci && npx myst build --html && node scripts/generate-feed.js && node scripts/aggregate-events.js && npx linkinator ./_build/html/ --skip /events-embed.html"
 
 [context.deploy-preview]
   ignore = "false"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,15 @@
         "@fontsource/atkinson-hyperlegible": "^5.2.8"
       },
       "devDependencies": {
+        "dompurify": "^3.4.9",
         "feed": "^5.2.0",
         "gray-matter": "^4.0.3",
+        "ical-generator": "^8.0.1",
         "linkinator": "^7.0.0",
         "mystmd": "^1.8.2",
+        "node-ical": "^0.20.1",
         "pa11y-ci": "^4.1.0",
+        "rss-parser": "^3.13.0",
         "serve": "^14.2.6"
       }
     },
@@ -100,6 +104,14 @@
       "dependencies": {
         "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -308,6 +320,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/axe-core": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
@@ -316,6 +335,56 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/b4a": {
@@ -522,6 +591,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -862,6 +945,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -1083,6 +1179,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/devtools-protocol": {
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
@@ -1147,6 +1253,16 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
+      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -1160,6 +1276,21 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -1244,6 +1375,55 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -1465,6 +1645,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1490,6 +1708,45 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -1618,6 +1875,19 @@
         "node": "*"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gray-matter": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
@@ -1642,6 +1912,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -1723,6 +2022,58 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/ical-generator": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-8.1.1.tgz",
+      "integrity": "sha512-vorfUDZk4NaVLB7f1pm9AeRGy0jTYn7QUHZCFCMx3EGOz9+yykdAjA1i4ez+ZLAEK55lmutCXvVovEdTj9s1XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uuid-random": "^1.3.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@touch4it/ical-timezones": ">=1.6.0",
+        "@types/luxon": ">= 1.26.0",
+        "@types/mocha": ">= 8.2.1",
+        "dayjs": ">= 1.10.0",
+        "luxon": ">= 1.26.0",
+        "moment": ">= 2.29.0",
+        "moment-timezone": ">= 0.5.33",
+        "rrule": ">= 2.6.8"
+      },
+      "peerDependenciesMeta": {
+        "@touch4it/ical-timezones": {
+          "optional": true
+        },
+        "@types/luxon": {
+          "optional": true
+        },
+        "@types/mocha": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-timezone": {
+          "optional": true
+        },
+        "rrule": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -2020,6 +2371,16 @@
         "marked": ">=13 <18"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/meow": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
@@ -2142,6 +2503,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2208,6 +2592,19 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-ical": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.20.1.tgz",
+      "integrity": "sha512-NrXgzDJd6XcyX9kDMJVA3xYCZmntY7ghA2BOdBeYr3iu8tydHOAb+68jPQhF9V2CRQ0/386X05XhmLzQUN0+Hw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "moment-timezone": "^0.5.45",
+        "rrule": "2.8.1",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/node.extend": {
@@ -2767,6 +3164,37 @@
         "node": ">=4"
       }
     },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/rss-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/rss-parser/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3236,6 +3664,28 @@
         "registry-url": "3.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3392,6 +3842,30 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "myst build --html && node scripts/generate-feed.js",
+    "build": "myst build --html && node scripts/generate-feed.js && node scripts/aggregate-events.js",
     "check-a11y": "serve _build/html -p 4117 & sleep 2 && pa11y-ci --sitemap http://localhost:4117/sitemap.xml --sitemap-find 'http://localhost:[0-9]+' --sitemap-replace 'http://localhost:4117'; kill %1",
     "check-links": "linkinator ./_build/html/ --recurse",
     "feed": "node scripts/generate-feed.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "feed": "node scripts/generate-feed.js",
     "events": "node scripts/aggregate-events.js",
     "validate-events": "node scripts/aggregate-events.js --validate-only",
-    "test": "node --test 'scripts/events/*.test.js'",
+    "test": "node --test scripts/events/*.test.js",
     "start": "myst start"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,14 +7,21 @@
     "check-a11y": "serve _build/html -p 4117 & sleep 2 && pa11y-ci --sitemap http://localhost:4117/sitemap.xml --sitemap-find 'http://localhost:[0-9]+' --sitemap-replace 'http://localhost:4117'; kill %1",
     "check-links": "linkinator ./_build/html/ --recurse",
     "feed": "node scripts/generate-feed.js",
+    "events": "node scripts/aggregate-events.js",
+    "validate-events": "node scripts/aggregate-events.js --validate-only",
+    "test": "node --test 'scripts/events/*.test.js'",
     "start": "myst start"
   },
   "devDependencies": {
+    "dompurify": "^3.4.9",
     "feed": "^5.2.0",
     "gray-matter": "^4.0.3",
+    "ical-generator": "^8.0.1",
     "linkinator": "^7.0.0",
     "mystmd": "^1.8.2",
+    "node-ical": "^0.20.1",
     "pa11y-ci": "^4.1.0",
+    "rss-parser": "^3.13.0",
     "serve": "^14.2.6"
   },
   "dependencies": {

--- a/scripts/aggregate-events.js
+++ b/scripts/aggregate-events.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Campus event aggregator. Reads every source in scripts/events/config.js,
+// merges them into one windowed set, and writes the embed/list JSON plus
+// subscribable .ics feeds into _build/html/feeds/.
+//
+// Run after `myst build --html` (like scripts/generate-feed.js). A scheduled
+// GitHub Action (.github/workflows/refresh-events.yml) triggers a rebuild so
+// the feeds stay current between pushes.
+//
+// Flags:
+//   --validate-only   Fetch and report per-source counts without writing.
+//                     Exits non-zero if any source errors—used for alerting.
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { SOURCES, FUTURE_WINDOW_DAYS } from "./events/config.js";
+import { fetchSource } from "./events/sources.js";
+import { withinWindow, dedupe, sortByStart } from "./events/normalize.js";
+import { writeOutputs } from "./events/outputs.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, "..", "_build", "html", "feeds");
+const validateOnly = process.argv.includes("--validate-only");
+
+const now = new Date();
+const to = new Date(+now + FUTURE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+const window = { from: now, to };
+
+const results = await Promise.allSettled(
+  SOURCES.map((s) => fetchSource(s, window)),
+);
+
+const collected = [];
+const failures = [];
+
+results.forEach((result, i) => {
+  const source = SOURCES[i];
+  if (result.status === "fulfilled") {
+    const inWindow = withinWindow(result.value, now, to);
+    collected.push(...inWindow);
+    const flag = inWindow.length === 0 ? "  ⚠ zero in-window events" : "";
+    console.log(`  ${source.id.padEnd(9)} ${String(inWindow.length).padStart(3)} events${flag}`);
+  } else {
+    failures.push({ id: source.id, error: result.reason?.message || String(result.reason) });
+    console.error(`  ${source.id.padEnd(9)} FAILED: ${result.reason?.message || result.reason}`);
+  }
+});
+
+const events = sortByStart(dedupe(collected));
+console.log(`\nMerged ${events.length} events across ${SOURCES.length - failures.length}/${SOURCES.length} sources (window: ${FUTURE_WINDOW_DAYS}d).`);
+
+if (validateOnly) {
+  // Health check for CI: loud failure if any source broke so a campus can't
+  // silently drop off the calendar.
+  if (failures.length) {
+    console.error(`\n${failures.length} source(s) failed: ${failures.map((f) => f.id).join(", ")}`);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+// Skip writing per-source feeds for sources that failed this run, so a campus
+// whose feed is briefly down keeps its last good .ics instead of being
+// overwritten with an empty one.
+const failedIds = new Set(failures.map((f) => f.id));
+
+try {
+  const summary = writeOutputs(events, OUT_DIR, failedIds);
+  console.log(`Wrote events.json + ${summary.icsFeeds} .ics feeds to ${summary.outDir}`);
+
+  // Copy the standalone calendar embed into the build root so it's served at
+  // /events-embed.html (the events page iframes it). MyST relocates/hashes files
+  // under static/, so we publish this one directly, like the feeds above.
+  const buildRoot = path.join(OUT_DIR, "..");
+  fs.copyFileSync(path.join(__dirname, "events", "embed.html"), path.join(buildRoot, "events-embed.html"));
+  console.log("Copied events-embed.html to build root");
+
+  // Vendor DOMPurify next to the embed so it loads from our own origin (served at
+  // /purify.min.js) instead of a third-party CDN. Version is pinned in
+  // package.json; bump it with `npm update dompurify`.
+  fs.copyFileSync(
+    path.join(__dirname, "..", "node_modules", "dompurify", "dist", "purify.min.js"),
+    path.join(buildRoot, "purify.min.js"),
+  );
+  console.log("Copied purify.min.js to build root");
+} catch (err) {
+  console.error(`\nFailed to write build outputs: ${err.message}`);
+  process.exit(1);
+}
+
+// Don't fail the site build if a single source is down—the page still
+// renders with the rest. The validate job is what alerts on failures.
+if (failures.length) {
+  console.warn(`\nNote: ${failures.length} source(s) were unavailable this run and are missing from the feeds.`);
+}

--- a/scripts/aggregate-events.js
+++ b/scripts/aggregate-events.js
@@ -84,6 +84,18 @@ try {
     path.join(buildRoot, "purify.min.js"),
   );
   console.log("Copied purify.min.js to build root");
+
+  // Vendor the site's Atkinson Hyperlegible font next to the embed so the iframe
+  // (a separate document that can't inherit the page's @font-face) renders in the
+  // site font. Served at /fonts/; keep the weights in sync with the @font-face in
+  // embed.html and static/css/custom.css.
+  const fontsDir = path.join(buildRoot, "fonts");
+  fs.mkdirSync(fontsDir, { recursive: true });
+  for (const weight of ["400", "700"]) {
+    const file = `atkinson-hyperlegible-latin-${weight}-normal.woff2`;
+    fs.copyFileSync(path.join(__dirname, "..", "static", "fonts", file), path.join(fontsDir, file));
+  }
+  console.log("Copied Atkinson Hyperlegible fonts to build root /fonts");
 } catch (err) {
   console.error(`\nFailed to write build outputs: ${err.message}`);
   process.exit(1);

--- a/scripts/aggregate-events.js
+++ b/scripts/aggregate-events.js
@@ -84,18 +84,6 @@ try {
     path.join(buildRoot, "purify.min.js"),
   );
   console.log("Copied purify.min.js to build root");
-
-  // Vendor the site's Atkinson Hyperlegible font next to the embed so the iframe
-  // (a separate document that can't inherit the page's @font-face) renders in the
-  // site font. Served at /fonts/; keep the weights in sync with the @font-face in
-  // embed.html and static/css/custom.css.
-  const fontsDir = path.join(buildRoot, "fonts");
-  fs.mkdirSync(fontsDir, { recursive: true });
-  for (const weight of ["400", "700"]) {
-    const file = `atkinson-hyperlegible-latin-${weight}-normal.woff2`;
-    fs.copyFileSync(path.join(__dirname, "..", "static", "fonts", file), path.join(fontsDir, file));
-  }
-  console.log("Copied Atkinson Hyperlegible fonts to build root /fonts");
 } catch (err) {
   console.error(`\nFailed to write build outputs: ${err.message}`);
   process.exit(1);

--- a/scripts/events/README.md
+++ b/scripts/events/README.md
@@ -1,0 +1,96 @@
+# Campus event aggregator
+
+Pulls every UC OSPO campus event calendar into one merged feed, calendar embed,
+and set of subscribable `.ics` files for the Events page. Each campus publishes
+on its own platform (Google Calendar, LiveWhale, Localist, a Hugo site); the
+aggregator reads those sources directly and merges them.
+
+## How it runs
+
+The aggregator runs at build time, right after `myst build` (same pattern as
+`generate-feed.js`). It's wired into the `html` target in the `Makefile`, which
+is what both production (`deploy.yml`) and PR checks use:
+
+```bash
+npx myst build --html && node scripts/generate-feed.js && node scripts/aggregate-events.js
+```
+
+It fetches all sources, merges/de-duplicates
+/windows them, and writes into
+`_build/html/feeds/`:
+
+| Output           | Path                                                 | Used by                      |
+| ---------------- | ---------------------------------------------------- | ---------------------------- |
+| Merged feed      | `/feeds/events.json`                                 | the calendar embed + list    |
+| Subscribe-all    | `/feeds/uc-ospo-all.ics`                             | "subscribe to everything"    |
+| Per-source feeds | `/feeds/{network,davis,ucsb,berkeley,ucsd,ucsc}.ics` | subscribe to any combination |
+
+## Staying fresh & deploy wiring
+
+Production is **GitHub Pages**: `deploy.yml` runs `make html` (which includes
+the aggregator) and pushes `_build/html` to the `UC-OSPO-Network.github.io`
+repo. Feeds are generated at build time, so they only change when that runs.
+
+`deploy.yml` runs on push to `main` **and on a 12h schedule**, so the feeds
+stay current with upstream campus calendars even during stretches with no
+pushes. The scheduled run reuses the existing `CI_DEPLOY_KEY` and needs no
+extra secret.
+
+Separately, `.github/workflows/refresh-events.yml` runs `validate-events` on a
+12h schedule and fails loudly if any campus source breaks. It only alerts; it
+does not deploy.
+
+(Netlify still builds PR previews via `netlify.toml` so the embed renders in
+previews, but it is not production.)
+
+Two consequences worth knowing:
+
+- **Subscriptions ride a rolling window.** Each rebuild re-runs the aggregator
+  with a fresh `FUTURE_WINDOW_DAYS` window, so a subscriber's calendar app
+  re-polling the `.ics` always sees the next ~120 days. They stay current _as
+  long as the scheduled deploy keeps running_. The durable fix is RRULE
+  pass-through (see TODOs).
+- **The subscribe links are absolute prod URLs** (`https://ucospo.net/feeds/…`
+  in `events/index.md`). That's intentional so subscriptions point at a stable
+  address, but it means PR previews link to the _production_ feeds, not the
+  preview build's own feeds.
+
+## Sources
+
+| Campus                         | Adapter          | Status                                                       |
+| ------------------------------ | ---------------- | ------------------------------------------------------------ |
+| Network (Google Cal)           | `ics`            | ✅                                                           |
+| UC Davis (Google Cal)          | `ics`            | ✅                                                           |
+| UC Santa Barbara (Google Cal)  | `ics`            | ✅                                                           |
+| UC Berkeley / BIDS (LiveWhale) | `ics` + `rssUrl` | ✅ .ics for times/location, RSS for descriptions (see below) |
+| UC San Diego (Localist)        | `localist`       | ✅ library group + `ospo` tag filter (0 upcoming now)        |
+| UC Santa Cruz (Hugo)           | `ucsc-rss`       | ✅ MVP via RSS; frontmatter upgrade pending                  |
+| UCLA                           | (none)           | omitted: no OSPO calendar yet                                |
+
+LiveWhale's `.ics` export omits `DESCRIPTION` entirely, so the Berkeley source
+also sets `rssUrl`: `fetchIcs` keeps the `.ics` for location/times/all-day and
+fills in descriptions from the matching RSS feed, keyed by title. Any future
+LiveWhale campus gets the same treatment by adding an `rssUrl` to its source.
+
+Add or change sources in `config.js`.
+
+## Open TODOs
+
+- **UCSC accuracy**: upgrade from RSS to reading per-event frontmatter from
+  `github.com/ucsc-ospo/ucsc-ospo.github.io` (`content/event/<slug>/index.md`)
+  for end times + location. `gray-matter` is already a dependency.
+- **Recurring subscriptions**: per-source `.ics` feeds carry the in-window
+  expanded occurrences (capped by `FUTURE_WINDOW_DAYS`), not the original
+  recurrence rules. They stay current via the rolling rebuild (see "Staying
+  fresh"), but the durable fix is to pass through original `RRULE`s so a
+  subscription recurs indefinitely without depending on constant rebuilds.
+- **Past events**: still the manual list in `events/index.md`. Decide later
+  whether to auto-generate from a wider backward window.
+
+## Local dev
+
+```bash
+npm install            # picks up node-ical, ical-generator, rss-parser
+npm run events         # writes feeds to _build/html/feeds/ (run after a build)
+npm run validate-events  # fetch + per-source counts, no write; non-zero on error
+```

--- a/scripts/events/README.md
+++ b/scripts/events/README.md
@@ -22,7 +22,6 @@ It fetches all sources, merges/de-duplicates
 | Output           | Path                                                 | Used by                      |
 | ---------------- | ---------------------------------------------------- | ---------------------------- |
 | Merged feed      | `/feeds/events.json`                                 | the calendar embed + list    |
-| Subscribe-all    | `/feeds/uc-ospo-all.ics`                             | "subscribe to everything"    |
 | Per-source feeds | `/feeds/{network,davis,ucsb,berkeley,ucsd,ucsc}.ics` | subscribe to any combination |
 
 ## Staying fresh & deploy wiring

--- a/scripts/events/config.js
+++ b/scripts/events/config.js
@@ -1,0 +1,81 @@
+// Source registry for the campus event aggregator.
+//
+// Each campus publishes events on its own platform. We read every source
+// directly and merge them. Most are plain iCal feeds;
+// UCSD and UCSC need adapters because they don't expose a usable .ics.
+//
+// See ./README.md for the full architecture, open TODOs, and deploy wiring.
+
+export const SITE_URL = "https://ucospo.net";
+
+// How far ahead the embed + list show events. Some calendars carry events that
+// recur for years, so we cap the forward window to keep the page sane. Past
+// events are handled separately (see README—Past Events stays manual for now).
+export const FUTURE_WINDOW_DAYS = 120;
+
+export const SOURCES = [
+  {
+    id: "network",
+    label: "UC OSPO Network",
+    type: "ics",
+    // Google Calendar (network-wide, all-campus events). Owned by Laura.
+    url: "https://calendar.google.com/calendar/ical/c_92ca749b4c01f221e16866c624be4377f8ccefbf0a079ec37f6960663c486e79%40group.calendar.google.com/public/basic.ics",
+  },
+  {
+    id: "davis",
+    label: "UC Davis",
+    type: "ics",
+    // Google Calendar, owned by Laura.
+    url: "https://calendar.google.com/calendar/ical/c_48b163b72d75bfb691a1b211d16d13bbaf98524e332586a0c9963d0fd83f7505%40group.calendar.google.com/public/basic.ics",
+  },
+  {
+    id: "ucsb",
+    label: "UC Santa Barbara",
+    type: "ics",
+    // Google Calendar (public).
+    url: "https://calendar.google.com/calendar/ical/c_99e456e1d3d1d5d320fb353647617fb72d9d9c01fc9368ed76e830c7e59108e6%40group.calendar.google.com/public/basic.ics",
+  },
+  {
+    id: "berkeley",
+    label: "UC Berkeley (BIDS)",
+    type: "ics",
+    // LiveWhale iCal feed for the "Berkeley Institute for Data Science" group
+    // (the /BIDS/all shortname maps to an empty group; this is the real feed).
+    url: "https://events.berkeley.edu/live/ical/events/group/Berkeley%20Institute%20for%20Data%20Science/header/Berkeley%20Institute%20for%20Data%20Science%20(BIDS)%20Events",
+    // LiveWhale's .ics omits DESCRIPTION; its RSS variant carries it. We keep
+    // the .ics for location/times/all-day and enrich descriptions from RSS,
+    // matched by title (see fetchIcs in sources.js).
+    rssUrl: "https://events.berkeley.edu/live/rss/events/group/Berkeley%20Institute%20for%20Data%20Science/header/BIDS",
+  },
+  {
+    id: "ucsd",
+    label: "UC San Diego",
+    type: "localist",
+    // Localist JSON API. No usable .ics (the .ics endpoint 406s), so we read
+    // JSON and synthesize iCal ourselves.
+    //
+    // group_id 49482217391481 is the "UC San Diego Library" group. The API
+    // ignores the widget's `tags=` param, so we fetch the library group and
+    // filter to OSPO events by tag client-side (see `tag` below + sources.js).
+    // Currently 0 upcoming—the OSPO events on https://ospo.ucsd.edu/events/
+    // are all past; new ospo-tagged events will flow through automatically.
+    base: "https://calendar.ucsd.edu/api/2/events",
+    params: { group_id: 49482217391481, days: 365, pp: 100 },
+    tag: "ospo",
+  },
+  {
+    id: "ucsc",
+    label: "UC Santa Cruz",
+    type: "ucsc-rss",
+    // Hugo site on GitHub Pages. MVP reads the RSS feed, where <pubDate> is the
+    // event date (verified against known event dates).
+    //
+    // TODO(accuracy): upgrade to reading per-event frontmatter from the repo
+    // (github.com/ucsc-ospo/ucsc-ospo.github.io, content/event/<slug>/index.md)
+    // for end times + location, which RSS doesn't carry. gray-matter is already
+    // a project dependency.
+    url: "https://ucsc-ospo.github.io/event/index.xml",
+  },
+  // UCLA: intentionally omitted. No OSPO calendar yet—events only land on the
+  // library's general events list. Add a source here when UCLA exposes a feed.
+];

--- a/scripts/events/embed.html
+++ b/scripts/events/embed.html
@@ -17,6 +17,15 @@
     <title>UC OSPO Network events</title>
     <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.css" rel="stylesheet" />
     <style>
+      :root {
+        /* Mirror the site brand palette (static/css/custom.css) so the popover
+           matches the rest of the page. This iframe is a separate document and
+           does NOT inherit the parent's --pst-* variables, so they're restated
+           here; keep in sync with custom.css if the brand colors change. */
+        --uco-primary: #003cb3; /* --pst-color-primary / --pst-color-link */
+        --uco-link-hover: #ff9100; /* --pst-color-link-hover */
+        --uco-text: #222832; /* --tw-prose-body */
+      }
       body {
         margin: 0;
         font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
@@ -246,6 +255,18 @@
         function sanitize(html) {
           return DOMPurify.sanitize(html || "");
         }
+        // True if the sanitized description already contains a link to `url`. When
+        // it does, the standalone "Open event link" button would just duplicate it
+        // (for our events `url` is the Zoom/registration link shown inline), so we
+        // suppress the button to avoid two competing links in the popover.
+        function descContainsUrl(html, url) {
+          if (!html || !url) return false;
+          const tmp = document.createElement("div");
+          tmp.innerHTML = html;
+          return [...tmp.querySelectorAll("a[href]")].some(
+            (a) => a.getAttribute("href") === url,
+          );
+        }
         function icsDate(d) {
           return d.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
         }
@@ -301,7 +322,7 @@
           refs.desc.style.display = descHtml ? "" : "none";
           refs.ics.onclick = () => addToCalendar(ev);
           refs.link.innerHTML = "";
-          if (p.url) {
+          if (p.url && !descContainsUrl(descHtml, p.url)) {
             const a = document.createElement("a");
             a.href = p.url;
             a.target = "_blank";

--- a/scripts/events/embed.html
+++ b/scripts/events/embed.html
@@ -17,19 +17,60 @@
     <title>UC OSPO Network events</title>
     <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.css" rel="stylesheet" />
     <style>
+      /* Site font (Atkinson Hyperlegible), mirrored from static/css/custom.css.
+         The iframe is a separate document, so the @font-face must be redeclared
+         here. MyST hashes files under static/, so the build (aggregate-events.js)
+         vendors these woff2s to /fonts/ next to the embed, same as purify.min.js. */
+      @font-face {
+        font-family: "Atkinson Hyperlegible";
+        font-style: normal;
+        font-weight: 400;
+        src: url("/fonts/atkinson-hyperlegible-latin-400-normal.woff2") format("woff2");
+      }
+      @font-face {
+        font-family: "Atkinson Hyperlegible";
+        font-style: normal;
+        font-weight: 700;
+        src: url("/fonts/atkinson-hyperlegible-latin-700-normal.woff2") format("woff2");
+      }
       :root {
-        /* Mirror the site brand palette (static/css/custom.css) so the popover
-           matches the rest of the page. This iframe is a separate document and
-           does NOT inherit the parent's --pst-* variables, so they're restated
-           here; keep in sync with custom.css if the brand colors change. */
-        --uco-primary: #003cb3; /* --pst-color-primary / --pst-color-link */
+        /* Mirror the site brand palette + font (static/css/custom.css) so the
+           embed matches the rest of the page. This iframe is a separate document
+           and does NOT inherit the parent's --pst-* variables, so they're
+           restated here. Change them in one place; keep in sync with custom.css. */
+        --uco-font: "Atkinson Hyperlegible", sans-serif;
+        --uco-primary: #003cb3; /* links, event tiles, button (--pst-color-link) */
         --uco-link-hover: #ff9100; /* --pst-color-link-hover */
-        --uco-text: #222832; /* --tw-prose-body */
+        --uco-text: #222832; /* body / popover text (--tw-prose-body) */
+        --uco-surface: #fff; /* popover card + button background */
+        --uco-border: #e0e0e0; /* popover card border */
+        --uco-muted: #767676; /* source label, close button */
+        --uco-daynum: #1a1a1a; /* current-month day number */
+        --uco-daynum-muted: #6b6b6b; /* other-month day number */
+        --uco-event-text: #fff; /* text on event tiles + button hover */
+      }
+      /* Dark mode follows the OS (prefers-color-scheme), which is how the site's
+         book-theme resolves its default/"system" appearance. Values mirror the
+         site's dark palette (#7ab3ff accent, light text on dark surfaces). */
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --uco-primary: #7ab3ff; /* .dark .article a in custom.css */
+          --uco-text: #e3e3e8;
+          --uco-surface: #1f1f1f;
+          --uco-border: #3a3a3a;
+          --uco-muted: #9aa0a6;
+          --uco-daynum: #e3e3e8;
+          --uco-daynum-muted: #8a8a8a;
+          --uco-event-text: #10243f; /* dark text on the lighter dark-mode tiles */
+        }
       }
       body {
         margin: 0;
-        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        font-family: var(--uco-font);
         color: var(--uco-text);
+        /* The parent page sizes this iframe to fit its content, so an internal
+           scrollbar is never needed; hide the sub-pixel-overflow one. */
+        overflow: hidden;
       }
       #calendar {
         max-width: 100%;
@@ -39,24 +80,25 @@
       .fc .fc-scrollgrid {
         border: 0;
       }
-      /* Brand-blue event tiles. FullCalendar's default event color renders white
-         text at ~3.7:1 (fails WCAG AA); #00609c gives ~6.6:1. */
+      /* Brand-blue event tiles (site --uco-primary). FullCalendar's default event
+         color renders white text at ~3.7:1 (fails WCAG AA); #003cb3 gives ~9:1. */
       .fc {
-        --fc-event-bg-color: #00609c;
-        --fc-event-border-color: #00609c;
+        --fc-event-bg-color: var(--uco-primary);
+        --fc-event-border-color: var(--uco-primary);
+        --fc-event-text-color: var(--uco-event-text);
       }
       /* FullCalendar's default day numbers are low-contrast: current-month ones
          are a light gray, and other-month ones are faded with opacity (which
          tanks contrast regardless of color). Darken current-month, and replace
          the other-month opacity with a muted-but-AA-passing gray. */
       .fc .fc-daygrid-day-number {
-        color: #1a1a1a;
+        color: var(--uco-daynum);
       }
       .fc .fc-daygrid-day.fc-day-other .fc-daygrid-day-top {
         opacity: 1;
       }
       .fc .fc-day-other .fc-daygrid-day-number {
-        color: #6b6b6b;
+        color: var(--uco-daynum-muted);
       }
       a {
         color: var(--uco-primary);
@@ -79,7 +121,8 @@
       }
       .evt-card {
         position: relative;
-        background: #fff;
+        background: var(--uco-surface);
+        border: 1px solid var(--uco-border);
         width: 100%;
         max-width: 420px;
         max-height: 90%;
@@ -96,14 +139,14 @@
         background: none;
         font-size: 22px;
         line-height: 1;
-        color: #666;
+        color: var(--uco-muted);
         cursor: pointer;
       }
       .evt-source {
         font-size: 0.8em;
         text-transform: uppercase;
         letter-spacing: 0.03em;
-        color: #767676;
+        color: var(--uco-muted);
       }
       .evt-card .evt-title {
         margin: 4px 24px 8px 0;
@@ -134,7 +177,7 @@
       }
       .evt-ics {
         border: 1px solid var(--uco-primary);
-        background: #fff;
+        background: var(--uco-surface);
         color: var(--uco-primary);
         border-radius: 6px;
         padding: 7px 12px;
@@ -144,7 +187,7 @@
       }
       .evt-ics:hover {
         background: var(--uco-primary);
-        color: #fff;
+        color: var(--uco-event-text);
       }
     </style>
   </head>

--- a/scripts/events/embed.html
+++ b/scripts/events/embed.html
@@ -20,7 +20,7 @@
       body {
         margin: 0;
         font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-        color: #1a1a1a;
+        color: var(--uco-text);
       }
       #calendar {
         max-width: 100%;
@@ -50,7 +50,10 @@
         color: #6b6b6b;
       }
       a {
-        color: #00609c;
+        color: var(--uco-primary);
+      }
+      a:hover {
+        color: var(--uco-link-hover);
       }
       .evt-modal {
         position: fixed;
@@ -100,11 +103,11 @@
       .evt-when,
       .evt-where {
         margin: 2px 0;
-        color: #333;
+        color: var(--uco-text);
       }
       .evt-desc {
         margin: 8px 0;
-        color: #444;
+        color: var(--uco-text);
         font-size: 0.92em;
         white-space: pre-wrap;
       }
@@ -121,9 +124,9 @@
         margin: 12px 0 0;
       }
       .evt-ics {
-        border: 1px solid #00609c;
+        border: 1px solid var(--uco-primary);
         background: #fff;
-        color: #00609c;
+        color: var(--uco-primary);
         border-radius: 6px;
         padding: 7px 12px;
         font-size: 0.9em;
@@ -131,7 +134,7 @@
         cursor: pointer;
       }
       .evt-ics:hover {
-        background: #00609c;
+        background: var(--uco-primary);
         color: #fff;
       }
     </style>

--- a/scripts/events/embed.html
+++ b/scripts/events/embed.html
@@ -17,28 +17,11 @@
     <title>UC OSPO Network events</title>
     <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.css" rel="stylesheet" />
     <style>
-      /* Site font (Atkinson Hyperlegible), mirrored from static/css/custom.css.
-         The iframe is a separate document, so the @font-face must be redeclared
-         here. MyST hashes files under static/, so the build (aggregate-events.js)
-         vendors these woff2s to /fonts/ next to the embed, same as purify.min.js. */
-      @font-face {
-        font-family: "Atkinson Hyperlegible";
-        font-style: normal;
-        font-weight: 400;
-        src: url("/fonts/atkinson-hyperlegible-latin-400-normal.woff2") format("woff2");
-      }
-      @font-face {
-        font-family: "Atkinson Hyperlegible";
-        font-style: normal;
-        font-weight: 700;
-        src: url("/fonts/atkinson-hyperlegible-latin-700-normal.woff2") format("woff2");
-      }
       :root {
-        /* Mirror the site brand palette + font (static/css/custom.css) so the
-           embed matches the rest of the page. This iframe is a separate document
-           and does NOT inherit the parent's --pst-* variables, so they're
-           restated here. Change them in one place; keep in sync with custom.css. */
-        --uco-font: "Atkinson Hyperlegible", sans-serif;
+        /* Mirror the site brand palette (static/css/custom.css) so the embed
+           matches the rest of the page. This iframe is a separate document and
+           does NOT inherit the parent's --pst-* variables, so they're restated
+           here. Change them in one place; keep in sync with custom.css. */
         --uco-primary: #003cb3; /* links, event tiles, button (--pst-color-link) */
         --uco-link-hover: #ff9100; /* --pst-color-link-hover */
         --uco-text: #222832; /* body / popover text (--tw-prose-body) */
@@ -66,7 +49,11 @@
       }
       body {
         margin: 0;
-        font-family: var(--uco-font);
+        /* Mirror the site's body font (static/css/custom.css) so the embed
+           behaves the same way the rest of the site does. No @font-face here, so
+           (like the site) this falls back to the reader's sans-serif unless
+           Atkinson is installed locally. */
+        font-family: "Atkinson Hyperlegible", sans-serif;
         color: var(--uco-text);
         /* The parent page sizes this iframe to fit its content, so an internal
            scrollbar is never needed; hide the sub-pixel-overflow one. */

--- a/scripts/events/embed.html
+++ b/scripts/events/embed.html
@@ -1,0 +1,349 @@
+<!doctype html>
+<!--
+  Standalone calendar embed for the Events page. Loaded via <iframe> from
+  events/index.md because MyST sanitizes page-level <script> tags—an iframe
+  is a separate document, so its scripts run normally.
+
+  Reads /feeds/events.json, written at build time by scripts/aggregate-events.js.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Standalone fragment, meant only to be iframed into /events/. Keep it out
+         of search so it is never indexed as an orphan page. -->
+    <meta name="robots" content="noindex" />
+    <base target="_blank" />
+    <title>UC OSPO Network events</title>
+    <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.css" rel="stylesheet" />
+    <style>
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        color: #1a1a1a;
+      }
+      #calendar {
+        max-width: 100%;
+      }
+      /* Drop FullCalendar's own outer frame so it doesn't double up with the
+         wrapper border on the parent page. */
+      .fc .fc-scrollgrid {
+        border: 0;
+      }
+      /* Brand-blue event tiles. FullCalendar's default event color renders white
+         text at ~3.7:1 (fails WCAG AA); #00609c gives ~6.6:1. */
+      .fc {
+        --fc-event-bg-color: #00609c;
+        --fc-event-border-color: #00609c;
+      }
+      /* FullCalendar's default day numbers are low-contrast: current-month ones
+         are a light gray, and other-month ones are faded with opacity (which
+         tanks contrast regardless of color). Darken current-month, and replace
+         the other-month opacity with a muted-but-AA-passing gray. */
+      .fc .fc-daygrid-day-number {
+        color: #1a1a1a;
+      }
+      .fc .fc-daygrid-day.fc-day-other .fc-daygrid-day-top {
+        opacity: 1;
+      }
+      .fc .fc-day-other .fc-daygrid-day-number {
+        color: #6b6b6b;
+      }
+      a {
+        color: #00609c;
+      }
+      .evt-modal {
+        position: fixed;
+        inset: 0;
+        z-index: 100000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 12px;
+        background: rgba(0, 0, 0, 0.4);
+      }
+      .evt-modal[hidden] {
+        display: none;
+      }
+      .evt-card {
+        position: relative;
+        background: #fff;
+        width: 100%;
+        max-width: 420px;
+        max-height: 90%;
+        overflow-y: auto;
+        border-radius: 8px;
+        padding: 18px 18px 20px;
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
+      }
+      .evt-close {
+        position: absolute;
+        top: 6px;
+        right: 10px;
+        border: 0;
+        background: none;
+        font-size: 22px;
+        line-height: 1;
+        color: #666;
+        cursor: pointer;
+      }
+      .evt-source {
+        font-size: 0.8em;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: #767676;
+      }
+      .evt-card .evt-title {
+        margin: 4px 24px 8px 0;
+        font-size: 1.1rem;
+      }
+      .evt-when,
+      .evt-where {
+        margin: 2px 0;
+        color: #333;
+      }
+      .evt-desc {
+        margin: 8px 0;
+        color: #444;
+        font-size: 0.92em;
+        white-space: pre-wrap;
+      }
+      .evt-link a {
+        display: inline-block;
+        margin-top: 6px;
+        font-weight: 600;
+      }
+      .evt-desc :is(ul, ol) {
+        margin: 6px 0;
+        padding-left: 20px;
+      }
+      .evt-actions {
+        margin: 12px 0 0;
+      }
+      .evt-ics {
+        border: 1px solid #00609c;
+        background: #fff;
+        color: #00609c;
+        border-radius: 6px;
+        padding: 7px 12px;
+        font-size: 0.9em;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      .evt-ics:hover {
+        background: #00609c;
+        color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="calendar"></div>
+    <div id="evt-modal" class="evt-modal" hidden>
+      <div class="evt-card" role="dialog" aria-modal="true" aria-labelledby="evt-title">
+        <button type="button" class="evt-close" aria-label="Close">&times;</button>
+        <div class="evt-source"></div>
+        <h3 id="evt-title" class="evt-title">Event details</h3>
+        <p class="evt-when"></p>
+        <p class="evt-where"></p>
+        <div class="evt-desc"></div>
+        <p class="evt-link"></p>
+        <p class="evt-actions">
+          <button type="button" class="evt-ics">Add to calendar</button>
+        </p>
+      </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js"></script>
+    <!-- Vendored at build time by scripts/aggregate-events.js (served from our
+         own origin, not a CDN). Version pinned in package.json. -->
+    <script src="/purify.min.js"></script>
+    <script>
+      (async () => {
+        let events = [];
+        try {
+          const res = await fetch("/feeds/events.json?v=" + Date.now());
+          if (res.ok) events = await res.json();
+        } catch (e) {
+          /* feed unavailable—render empty */
+        }
+
+        // Interactive calendar (month grid + agenda-style list toggle).
+        const cal = new FullCalendar.Calendar(document.getElementById("calendar"), {
+          initialView: "dayGridMonth",
+          headerToolbar: {
+            left: "prev,next today",
+            center: "title",
+            right: "dayGridMonth,listMonth",
+          },
+          height: "auto",
+          eventDisplay: "block",
+          datesSet: fit,
+          eventClick: function (info) {
+            // Show event details in a popover instead of navigating straight to
+            // the link (which would, e.g., drop people into a Zoom meeting).
+            info.jsEvent.preventDefault();
+            showEvent(info.event);
+          },
+          events: events.map((e) => ({
+            title: e.title,
+            start: e.start,
+            end: e.end,
+            allDay: e.allDay,
+            extendedProps: {
+              url: e.url || null,
+              location: e.location || null,
+              description: e.description || null,
+              descriptionHtml: e.descriptionHtml || null,
+              sourceLabel: e.sourceLabel || null,
+            },
+          })),
+        });
+        // Size the parent iframe wrapper to the calendar's real height so there
+        // is no empty space below it (and no clipping). Refit on view change
+        // (datesSet) and window resize. Same origin, so frameElement is reachable.
+        function fit() {
+          requestAnimationFrame(() => {
+            const calEl = document.getElementById("calendar");
+            if (!calEl) return;
+            const h = Math.ceil(calEl.getBoundingClientRect().bottom) + 2;
+            const wrap = window.frameElement && window.frameElement.parentElement;
+            if (wrap) wrap.style.height = h + "px";
+          });
+        }
+
+        cal.render();
+        fit();
+        window.addEventListener("resize", fit);
+
+        // Event-details popover (instead of navigating straight to the link).
+        const modal = document.getElementById("evt-modal");
+        const refs = {
+          source: modal.querySelector(".evt-source"),
+          title: modal.querySelector(".evt-title"),
+          when: modal.querySelector(".evt-when"),
+          where: modal.querySelector(".evt-where"),
+          desc: modal.querySelector(".evt-desc"),
+          link: modal.querySelector(".evt-link"),
+          ics: modal.querySelector(".evt-ics"),
+        };
+        function set(el, text) {
+          el.textContent = text;
+          el.style.display = text ? "" : "none";
+        }
+        // DOMPurify does the sanitizing (allowlist: drops scripts, event
+        // handlers, dangerous URIs, and stray tags like <base>/<form>). This
+        // hook adds the one non-sanitizing touch we want: force event links to
+        // open safely in a new tab.
+        DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+          if (node.tagName === "A") {
+            node.setAttribute("target", "_blank");
+            node.setAttribute("rel", "noopener noreferrer");
+          }
+        });
+        function sanitize(html) {
+          return DOMPurify.sanitize(html || "");
+        }
+        function icsDate(d) {
+          return d.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
+        }
+        function icsEscape(s) {
+          return String(s || "")
+            .replace(/([,;])/g, "\\$1")
+            .replace(/\r?\n/g, "\\n");
+        }
+        function addToCalendar(ev) {
+          const p = ev.extendedProps || {};
+          const lines = [
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "PRODID:-//UC OSPO Network//Events//EN",
+            "BEGIN:VEVENT",
+            "UID:" + (ev.id || "evt-" + ev.start.getTime()) + "@ucospo.net",
+            "DTSTAMP:" + icsDate(new Date()),
+            "DTSTART:" + icsDate(ev.start),
+          ];
+          if (ev.end) lines.push("DTEND:" + icsDate(ev.end));
+          lines.push("SUMMARY:" + icsEscape(ev.title));
+          if (p.location) lines.push("LOCATION:" + icsEscape(p.location));
+          if (p.description) lines.push("DESCRIPTION:" + icsEscape(p.description));
+          if (p.url) lines.push("URL:" + p.url);
+          lines.push("END:VEVENT", "END:VCALENDAR");
+          const blob = new Blob([lines.join("\r\n")], { type: "text/calendar" });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download =
+            (ev.title || "event").replace(/[^a-z0-9]+/gi, "-").toLowerCase() + ".ics";
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          setTimeout(() => URL.revokeObjectURL(url), 1000);
+        }
+        let lastFocused = null;
+        function showEvent(ev) {
+          const p = ev.extendedProps || {};
+          set(refs.source, p.sourceLabel || "");
+          refs.title.textContent = ev.title || "Event";
+          const dOpts = { weekday: "long", month: "long", day: "numeric", year: "numeric" };
+          const tOpts = { hour: "numeric", minute: "2-digit" };
+          let when = ev.start ? ev.start.toLocaleDateString("en-US", dOpts) : "";
+          if (ev.start && !ev.allDay) {
+            when += " at " + ev.start.toLocaleTimeString("en-US", tOpts);
+            if (ev.end) when += " to " + ev.end.toLocaleTimeString("en-US", tOpts);
+          }
+          set(refs.when, when);
+          set(refs.where, p.location ? "Where: " + p.location : "");
+          const descHtml = sanitize(p.descriptionHtml || "");
+          refs.desc.innerHTML = descHtml;
+          refs.desc.style.display = descHtml ? "" : "none";
+          refs.ics.onclick = () => addToCalendar(ev);
+          refs.link.innerHTML = "";
+          if (p.url) {
+            const a = document.createElement("a");
+            a.href = p.url;
+            a.target = "_blank";
+            a.rel = "noopener noreferrer";
+            a.textContent = "Open event link";
+            refs.link.appendChild(a);
+            refs.link.style.display = "";
+          } else {
+            refs.link.style.display = "none";
+          }
+          lastFocused = document.activeElement;
+          modal.hidden = false;
+          modal.querySelector(".evt-close").focus();
+        }
+        function hideEvent() {
+          modal.hidden = true;
+          if (lastFocused && lastFocused.focus) lastFocused.focus();
+          lastFocused = null;
+        }
+        modal.addEventListener("click", (e) => {
+          if (e.target === modal) hideEvent();
+        });
+        modal.querySelector(".evt-close").addEventListener("click", hideEvent);
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape" && !modal.hidden) hideEvent();
+        });
+        // Trap Tab within the open dialog (focus is moved in on open and restored
+        // on close above) so keyboard users can't tab to the calendar behind it.
+        modal.addEventListener("keydown", (e) => {
+          if (e.key !== "Tab" || modal.hidden) return;
+          const f = [...modal.querySelectorAll('a[href], button:not([disabled])')].filter(
+            (el) => el.offsetParent !== null,
+          );
+          if (!f.length) return;
+          const first = f[0];
+          const last = f[f.length - 1];
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/scripts/events/normalize.js
+++ b/scripts/events/normalize.js
@@ -1,0 +1,70 @@
+// The common event model every source adapter normalizes into, plus helpers
+// for windowing, de-duplicating, and sorting the merged set.
+//
+// Shape of a normalized event:
+//   {
+//     uid:         string   // stable, unique (source id + source's own id)
+//     sourceId:    string   // 'network' | 'davis' | ... (matches config.SOURCES)
+//     sourceLabel: string   // human label, e.g. 'UC Berkeley (BIDS)'
+//     title:       string
+//     start:       Date
+//     end:         Date | null
+//     allDay:      boolean
+//     location:    string | null
+//     url:         string | null   // link to the event detail page / registration
+//     description: string | null
+//   }
+
+export function makeEvent(source, fields) {
+  return {
+    uid: `${source.id}:${fields.id}`,
+    sourceId: source.id,
+    sourceLabel: source.label,
+    title: (fields.title || "Untitled event").trim(),
+    start: fields.start,
+    end: fields.end ?? null,
+    allDay: Boolean(fields.allDay),
+    location: fields.location?.trim() || null,
+    url: fields.url || null,
+    description: fields.description?.trim() || null,
+    descriptionHtml: fields.descriptionHtml || null,
+  };
+}
+
+// Keep events that end (or start, if no end) on/after `from` and start before
+// `to`. Drops events with no usable start date.
+export function withinWindow(events, from, to) {
+  return events.filter((e) => {
+    if (!(e.start instanceof Date) || isNaN(e.start)) return false;
+    const effectiveEnd = e.end instanceof Date && !isNaN(e.end) ? e.end : e.start;
+    return effectiveEnd >= from && e.start <= to;
+  });
+}
+
+// De-duplicate across sources. Same talk can appear on both a campus calendar
+// and the network calendar; collapse on a normalized title + start-time key.
+export function dedupe(events) {
+  const byKey = new Map();
+  for (const e of events) {
+    const key = `${e.title.toLowerCase().replace(/\s+/g, " ")}@${e.start?.toISOString?.() ?? ""}`;
+    const existing = byKey.get(key);
+    byKey.set(key, existing ? preferred(existing, e) : e);
+  }
+  return [...byKey.values()];
+}
+
+// Which of two colliding copies to keep:
+//   1. Network-owned wins, so the canonical all-campus listing is preferred.
+//   2. Same source: keep the richer description. A host editing one occurrence
+//      to set that month's topic (which can land on another occurrence's slot
+//      when also rescheduled) must not lose to the generic recurring blurb.
+function preferred(a, b) {
+  const aNet = a.sourceId === "network";
+  const bNet = b.sourceId === "network";
+  if (aNet !== bNet) return aNet ? a : b;
+  return (b.description?.length ?? 0) > (a.description?.length ?? 0) ? b : a;
+}
+
+export function sortByStart(events) {
+  return [...events].sort((a, b) => a.start - b.start);
+}

--- a/scripts/events/normalize.test.js
+++ b/scripts/events/normalize.test.js
@@ -1,0 +1,113 @@
+// Unit tests for the merge/window/dedupe helpers. These are the bug-prone,
+// pure-function parts of the aggregator. Run with `npm test` (node --test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeEvent, withinWindow, dedupe, sortByStart } from "./normalize.js";
+
+const src = (id) => ({ id, label: id.toUpperCase() });
+const ev = (id, fields) => makeEvent(src(id), fields);
+
+const FROM = new Date("2026-06-01T00:00:00Z");
+const TO = new Date("2026-09-29T00:00:00Z"); // ~120 days later
+
+// --- withinWindow ----------------------------------------------------------
+
+test("withinWindow keeps an event starting inside the window", () => {
+  const e = ev("davis", { id: "1", title: "In window", start: new Date("2026-07-01T17:00:00Z") });
+  assert.deepEqual(withinWindow([e], FROM, TO), [e]);
+});
+
+test("withinWindow drops an event with no usable start date", () => {
+  const e = ev("davis", { id: "2", title: "No start", start: undefined });
+  assert.deepEqual(withinWindow([e], FROM, TO), []);
+});
+
+test("withinWindow drops an event starting after the window", () => {
+  const e = ev("davis", { id: "3", title: "Too late", start: new Date("2026-10-15T17:00:00Z") });
+  assert.deepEqual(withinWindow([e], FROM, TO), []);
+});
+
+test("withinWindow keeps an event that started before the window but is still ongoing", () => {
+  const e = ev("davis", {
+    id: "4",
+    title: "Ongoing",
+    start: new Date("2026-05-20T17:00:00Z"),
+    end: new Date("2026-06-05T17:00:00Z"),
+  });
+  assert.deepEqual(withinWindow([e], FROM, TO), [e]);
+});
+
+test("withinWindow drops a past event with no end (start used as the effective end)", () => {
+  const e = ev("davis", { id: "5", title: "Past", start: new Date("2026-05-01T17:00:00Z") });
+  assert.deepEqual(withinWindow([e], FROM, TO), []);
+});
+
+// --- dedupe / preferred ----------------------------------------------------
+
+test("dedupe collapses the same event across campuses, keeping the network copy", () => {
+  const start = new Date("2026-07-02T17:00:00Z");
+  const networkCopy = ev("network", { id: "n1", title: "All-Campus Meetup", start, description: "short" });
+  const campusCopy = ev("davis", {
+    id: "d1",
+    title: "All-Campus Meetup",
+    start,
+    description: "a much longer, richer description from the campus calendar",
+  });
+  const out = dedupe([campusCopy, networkCopy]);
+  assert.equal(out.length, 1);
+  // Network wins even though the campus copy has the richer description.
+  assert.equal(out[0].sourceId, "network");
+});
+
+test("dedupe keeps the richer description when both copies are from the same source", () => {
+  const start = new Date("2026-07-02T17:00:00Z");
+  const generic = ev("davis", { id: "d1", title: "Meetup", start, description: "short" });
+  const detailed = ev("davis", { id: "d2", title: "Meetup", start, description: "a much longer, richer description" });
+  const out = dedupe([generic, detailed]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].description, "a much longer, richer description");
+});
+
+test("dedupe treats titles differing only in case/whitespace as the same event", () => {
+  const start = new Date("2026-07-02T17:00:00Z");
+  const a = ev("davis", { id: "d1", title: "Open  Source   Meetup", start });
+  const b = ev("davis", { id: "d2", title: "open source meetup", start });
+  assert.equal(dedupe([a, b]).length, 1);
+});
+
+test("dedupe keeps genuinely different events", () => {
+  const start = new Date("2026-07-02T17:00:00Z");
+  const a = ev("davis", { id: "d1", title: "Event A", start });
+  const b = ev("davis", { id: "d2", title: "Event B", start });
+  assert.equal(dedupe([a, b]).length, 2);
+});
+
+// --- sortByStart -----------------------------------------------------------
+
+test("sortByStart orders by start ascending without mutating the input", () => {
+  const a = ev("davis", { id: "a", title: "A", start: new Date("2026-08-01T00:00:00Z") });
+  const b = ev("davis", { id: "b", title: "B", start: new Date("2026-06-15T00:00:00Z") });
+  const c = ev("davis", { id: "c", title: "C", start: new Date("2026-07-10T00:00:00Z") });
+  const input = [a, b, c];
+  const out = sortByStart(input);
+  assert.deepEqual(out.map((e) => e.title), ["B", "C", "A"]);
+  assert.deepEqual(input.map((e) => e.title), ["A", "B", "C"]); // input untouched
+});
+
+// --- makeEvent -------------------------------------------------------------
+
+test("makeEvent builds a stable uid and normalizes fields", () => {
+  const e = ev("davis", {
+    id: "42",
+    title: "  Spaced  ",
+    start: new Date("2026-07-02T17:00:00Z"),
+    description: "  hi  ",
+  });
+  assert.equal(e.uid, "davis:42");
+  assert.equal(e.sourceId, "davis");
+  assert.equal(e.title, "Spaced");
+  assert.equal(e.description, "hi");
+  assert.equal(e.end, null);
+  assert.equal(e.allDay, false);
+});

--- a/scripts/events/outputs.js
+++ b/scripts/events/outputs.js
@@ -1,0 +1,72 @@
+// Writes the build artifacts the events page consumes:
+//   - events.json        : merged, windowed feed for the calendar embed + list
+//   - <source>.ics        : one subscribable feed per campus (+ network)
+//   - uc-ospo-all.ics      : everything merged, for "subscribe to all"
+//
+// Subscribe-to-any-combination is covered by per-source feeds: a user who wants
+// "network + my campus" subscribes to network.ics and their campus's .ics.
+
+import icalGenerator from "ical-generator";
+import fs from "fs";
+import path from "path";
+import { SITE_URL, SOURCES } from "./config.js";
+
+function buildCalendar(name, events) {
+  const cal = icalGenerator({ name, prodId: { company: "UC OSPO Network", product: "events" } });
+  for (const e of events) {
+    cal.createEvent({
+      id: e.uid,
+      start: e.start,
+      end: e.end || undefined,
+      allDay: e.allDay,
+      summary: e.title,
+      location: e.location || undefined,
+      description: e.description || undefined,
+      url: e.url || undefined,
+    });
+  }
+  return cal.toString();
+}
+
+export function writeOutputs(events, outDir, failedIds = new Set()) {
+  fs.mkdirSync(outDir, { recursive: true });
+
+  // 1. JSON feed for the embed + list (FullCalendar-shaped).
+  const json = events.map((e) => ({
+    id: e.uid,
+    title: e.title,
+    start: e.start.toISOString(),
+    end: e.end ? e.end.toISOString() : null,
+    allDay: e.allDay,
+    url: e.url,
+    source: e.sourceId,
+    sourceLabel: e.sourceLabel,
+    location: e.location,
+    description: e.description,
+    descriptionHtml: e.descriptionHtml,
+  }));
+  fs.writeFileSync(path.join(outDir, "events.json"), JSON.stringify(json, null, 2));
+
+  // 2. Merged "everything" feed.
+  // TODO: pass through original RRULEs for true recurring subscriptions;
+  // right now feeds carry the in-window expanded occurrences only.
+  fs.writeFileSync(
+    path.join(outDir, "uc-ospo-all.ics"),
+    buildCalendar("UC OSPO Network—All Campuses", events),
+  );
+
+  // 3. One feed per source. Skip sources that failed this run so we keep the
+  //    last good feed instead of overwriting it with an empty one.
+  let perSourceFeeds = 0;
+  for (const source of SOURCES) {
+    if (failedIds.has(source.id)) continue;
+    const subset = events.filter((e) => e.sourceId === source.id);
+    fs.writeFileSync(
+      path.join(outDir, `${source.id}.ics`),
+      buildCalendar(`UC OSPO—${source.label}`, subset),
+    );
+    perSourceFeeds++;
+  }
+
+  return { count: events.length, icsFeeds: perSourceFeeds + 1, outDir, site: SITE_URL };
+}

--- a/scripts/events/outputs.js
+++ b/scripts/events/outputs.js
@@ -1,7 +1,6 @@
 // Writes the build artifacts the events page consumes:
 //   - events.json        : merged, windowed feed for the calendar embed + list
 //   - <source>.ics        : one subscribable feed per campus (+ network)
-//   - uc-ospo-all.ics      : everything merged, for "subscribe to all"
 //
 // Subscribe-to-any-combination is covered by per-source feeds: a user who wants
 // "network + my campus" subscribes to network.ics and their campus's .ics.
@@ -47,16 +46,10 @@ export function writeOutputs(events, outDir, failedIds = new Set()) {
   }));
   fs.writeFileSync(path.join(outDir, "events.json"), JSON.stringify(json, null, 2));
 
-  // 2. Merged "everything" feed.
-  // TODO: pass through original RRULEs for true recurring subscriptions;
-  // right now feeds carry the in-window expanded occurrences only.
-  fs.writeFileSync(
-    path.join(outDir, "uc-ospo-all.ics"),
-    buildCalendar("UC OSPO Network—All Campuses", events),
-  );
-
-  // 3. One feed per source. Skip sources that failed this run so we keep the
+  // 2. One feed per source. Skip sources that failed this run so we keep the
   //    last good feed instead of overwriting it with an empty one.
+  // TODO: pass through original RRULEs for true recurring subscriptions;
+  //       right now feeds carry the in-window expanded occurrences only.
   let perSourceFeeds = 0;
   for (const source of SOURCES) {
     if (failedIds.has(source.id)) continue;
@@ -68,5 +61,5 @@ export function writeOutputs(events, outDir, failedIds = new Set()) {
     perSourceFeeds++;
   }
 
-  return { count: events.length, icsFeeds: perSourceFeeds + 1, outDir, site: SITE_URL };
+  return { count: events.length, icsFeeds: perSourceFeeds, outDir, site: SITE_URL };
 }

--- a/scripts/events/sources.js
+++ b/scripts/events/sources.js
@@ -1,0 +1,289 @@
+// Per-platform adapters. Each returns an array of normalized events
+// (see normalize.js). Recurring events from iCal feeds are expanded into
+// individual occurrences within the requested window.
+
+import ical from "node-ical";
+import Parser from "rss-parser";
+import { makeEvent } from "./normalize.js";
+
+// Abort any source fetch that stalls, so one slow campus server can't hang the
+// whole build (Node's global fetch has no default timeout).
+const FETCH_TIMEOUT_MS = 15000;
+
+// HTML to plain text, but keep the structure (line breaks + list bullets) so
+// the .ics DESCRIPTION reads properly in a subscriber's calendar app instead of
+// collapsing to one line.
+function stripHtml(html) {
+  if (!html) return null;
+  const text = html
+    .replace(/<\s*br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|li|h[1-6]|tr)\s*>/gi, "\n")
+    .replace(/<\s*li[^>]*>/gi, "- ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;|&#x27;/gi, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/[ \t]*\n[ \t]*/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return text || null;
+}
+
+// Google Calendar iCal exports omit the URL property but put the
+// registration/Zoom link in the (HTML) description. Fall back to a link there so
+// events stay clickable. Prefer a meeting/registration link over an incidental
+// content link (e.g. a speaker's project page), else take the first URL.
+function firstUrl(html) {
+  if (!html) return null;
+  const urls = [...html.matchAll(/https?:\/\/[^\s"'<>)]+/gi)].map((m) =>
+    m[0].replace(/&amp;/g, "&"),
+  );
+  if (!urls.length) return null;
+  const preferred = urls.find((u) =>
+    /zoom\.us|\/register|eventbrite|meet\.google|teams\.microsoft/i.test(u),
+  );
+  return preferred || urls[0];
+}
+
+// node-ical's rrule expansion yields occurrences with the right wall-clock time
+// but labeled UTC, which drops the calendar's real offset (10:00 Pacific comes
+// out as 10:00Z). Re-anchor such a naive Date: read its UTC fields as the
+// intended local time and return the correct absolute instant in `tz` (DST-aware
+// via Intl).
+function tzOffsetMs(date, tz) {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const p = Object.fromEntries(
+    dtf.formatToParts(date).map((x) => [x.type, x.value]),
+  );
+  const asUTC = Date.UTC(
+    +p.year,
+    +p.month - 1,
+    +p.day,
+    +p.hour,
+    +p.minute,
+    +p.second,
+  );
+  return asUTC - date.getTime();
+}
+function wallToZoned(naive, tz) {
+  const utcGuess = Date.UTC(
+    naive.getUTCFullYear(),
+    naive.getUTCMonth(),
+    naive.getUTCDate(),
+    naive.getUTCHours(),
+    naive.getUTCMinutes(),
+    naive.getUTCSeconds(),
+  );
+  return new Date(utcGuess - tzOffsetMs(new Date(utcGuess), tz));
+}
+
+// Google Calendar inserts Unicode line/paragraph separators (U+2028/U+2029)
+// into descriptions pasted from rich text (Docs/Word). node-ical's line
+// unfolder treats them as line breaks, mis-parses the fold, and silently drops
+// the ENTIRE DESCRIPTION property. Neutralize them before parsing. (NBSP and
+// other non-terminator chars are fine—they don't break the unfolder.)
+const ICS_LINE_SEPARATORS = /[\u2028\u2029]/g;
+
+const titleKey = (t) => (t || "").toLowerCase().replace(/\s+/g, " ").trim();
+
+// RSS item bodies often lead with the group's logo image; drop leading media so
+// the popover opens on the description text, not a thumbnail.
+function stripLeadingMedia(html) {
+  return html
+    .replace(/^\s*<picture[\s\S]*?<\/picture>\s*/i, "")
+    .replace(/^\s*<img[^>]*>\s*/i, "")
+    .trim();
+}
+
+// LiveWhale's .ics omits DESCRIPTION, but its RSS variant carries it. Build a
+// title -> description map from the RSS feed so fetchIcs can fill the gap while
+// keeping the .ics's location/times. Best-effort: a missing/broken RSS feed
+// just leaves descriptions empty rather than failing the source.
+async function fetchRssDescriptions(url) {
+  const map = new Map();
+  try {
+    const feed = await rss.parseURL(url);
+    for (const item of feed.items || []) {
+      const key = titleKey(item.title);
+      if (!key || map.has(key)) continue;
+      const html = stripLeadingMedia(item.content || "");
+      map.set(key, {
+        description: item.contentSnippet?.trim() || stripHtml(html),
+        descriptionHtml: html || null,
+        url: item.link || null,
+      });
+    }
+  } catch {
+    // Enrichment is optional; .ics events still render without descriptions.
+  }
+  return map;
+}
+
+// --- iCal feeds: Berkeley (LiveWhale) + the three Google Calendars ----------
+async function fetchIcs(source, { from, to }) {
+  const res = await fetch(source.url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!res.ok) throw new Error(`ICS HTTP ${res.status} for ${source.id}`);
+  const text = (await res.text()).replace(ICS_LINE_SEPARATORS, " ");
+  const data = ical.sync.parseICS(text);
+  const events = [];
+
+  for (const ev of Object.values(data)) {
+    if (ev.type !== "VEVENT" || !ev.start) continue;
+
+    const base = {
+      title: ev.summary,
+      location: ev.location,
+      url: ev.url || firstUrl(ev.description) || null,
+      description: stripHtml(ev.description),
+      descriptionHtml: ev.description || null,
+      allDay: ev.datetype === "date",
+    };
+    const durationMs =
+      ev.end instanceof Date && ev.start instanceof Date ? ev.end - ev.start : null;
+
+    if (ev.rrule) {
+      // Recurring: expand occurrences in-window, honoring EXDATEs and
+      // per-instance overrides (RECURRENCE-ID). node-ical keys ev.recurrences
+      // by the overridden occurrence's date (YYYY-MM-DD). A host editing a
+      // single occurrence (e.g. setting that month's All-Campus topic, or
+      // rescheduling it) lands there, so we skip the generic master at any
+      // overridden slot and emit the override at its own start below.
+      const tz = ev.rrule.origOptions?.tzid || "America/Los_Angeles";
+      const exdates = new Set(Object.values(ev.exdate || {}).map((d) => +d));
+      const overrides = ev.recurrences || {};
+      for (const occ of ev.rrule.between(from, to, true)) {
+        if (exdates.has(+occ)) continue;
+        if (overrides[occ.toISOString().slice(0, 10)]) continue; // replaced below
+        const start = wallToZoned(occ, tz);
+        events.push(
+          makeEvent(source, {
+            ...base,
+            id: `${ev.uid}-${occ.toISOString()}`,
+            start,
+            end: durationMs != null ? new Date(+start + durationMs) : null,
+          }),
+        );
+      }
+      // Override starts are already absolute (no wallToZoned). Out-of-window
+      // and cancelled overrides are dropped (withinWindow + the status check).
+      for (const ov of Object.values(overrides)) {
+        if (!ov.start || ov.status === "CANCELLED") continue;
+        events.push(
+          makeEvent(source, {
+            id: `${ev.uid}-${(ov.recurrenceid ?? ov.start).toISOString()}`,
+            title: ov.summary ?? base.title,
+            location: ov.location,
+            url: ov.url || firstUrl(ov.description) || null,
+            description: stripHtml(ov.description),
+            descriptionHtml: ov.description || null,
+            allDay: ov.datetype === "date",
+            start: ov.start,
+            end: ov.end || null,
+          }),
+        );
+      }
+    } else {
+      events.push(
+        makeEvent(source, { ...base, id: ev.uid, start: ev.start, end: ev.end || null }),
+      );
+    }
+  }
+
+  // Enrich descriptions from a sibling RSS feed (LiveWhale .ics omits them).
+  if (source.rssUrl) {
+    const descByTitle = await fetchRssDescriptions(source.rssUrl);
+    for (const ev of events) {
+      if (ev.description) continue;
+      const hit = descByTitle.get(titleKey(ev.title));
+      if (!hit) continue;
+      ev.description = hit.description;
+      ev.descriptionHtml = hit.descriptionHtml;
+      ev.url = ev.url || hit.url;
+    }
+  }
+  return events;
+}
+
+// --- UCSD: Localist JSON API ------------------------------------------------
+async function fetchLocalist(source) {
+  const url = new URL(source.base);
+  for (const [k, v] of Object.entries(source.params)) {
+    if (v != null) url.searchParams.set(k, String(v));
+  }
+  const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!res.ok) throw new Error(`Localist HTTP ${res.status}`);
+  const data = await res.json();
+
+  const events = [];
+  for (const wrapper of data.events || []) {
+    const ev = wrapper.event;
+    // The API ignores the tags= query param, so filter by tag here.
+    if (source.tag) {
+      const tags = (ev.tags || []).map((t) => String(t).toLowerCase());
+      if (!tags.includes(source.tag.toLowerCase())) continue;
+    }
+    // TODO: Localist can return multiple event_instances (recurring); we take
+    // the first for now.
+    const inst = ev.event_instances?.[0]?.event_instance;
+    if (!inst?.start) continue;
+    events.push(
+      makeEvent(source, {
+        id: String(ev.id),
+        title: ev.title,
+        start: new Date(inst.start),
+        end: inst.end ? new Date(inst.end) : null,
+        allDay: Boolean(inst.all_day),
+        location: ev.location_name || ev.room_number || null,
+        url: ev.localist_url || ev.url || null,
+        description: ev.description_text || stripHtml(ev.description),
+        descriptionHtml: ev.description || null,
+      }),
+    );
+  }
+  return events;
+}
+
+// --- UCSC: Hugo RSS (MVP; see config TODO for the frontmatter upgrade) ------
+const rss = new Parser({ timeout: FETCH_TIMEOUT_MS });
+async function fetchUcscRss(source) {
+  const feed = await rss.parseURL(source.url);
+  return (feed.items || []).map((item, i) =>
+    makeEvent(source, {
+      id: item.guid || item.link || `ucsc-${i}`,
+      title: item.title,
+      // <pubDate> is the event date for this feed (verified). No end/location in RSS.
+      start: item.isoDate ? new Date(item.isoDate) : new Date(item.pubDate),
+      end: null,
+      allDay: false,
+      location: null,
+      url: item.link || null,
+      description: item.contentSnippet || null,
+      descriptionHtml: item.content || null,
+    }),
+  );
+}
+
+const ADAPTERS = {
+  ics: fetchIcs,
+  localist: fetchLocalist,
+  "ucsc-rss": fetchUcscRss,
+};
+
+export async function fetchSource(source, window) {
+  const adapter = ADAPTERS[source.type];
+  if (!adapter) throw new Error(`No adapter for source type "${source.type}"`);
+  return adapter(source, window);
+}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -809,3 +809,21 @@ figcaption,
     margin: 0 auto 1rem auto !important;
   }
 }
+
+/* Events page: replace MyST's default aspect-ratio iframe box with a fixed
+   height for the campus-calendar embed (/events-embed.html). MyST wraps raw
+   iframes in a .relative.inline-block div with inline padding-bottom. */
+.relative.inline-block:has(> iframe[src^="/events-embed.html"]) {
+  padding-bottom: 0 !important;
+  height: 600px;
+  width: 100%;
+  border: 2px solid #cccccc;
+}
+.relative.inline-block:has(> iframe[src^="/events-embed.html"])
+  > iframe[src^="/events-embed.html"] {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}


### PR DESCRIPTION
**TL;DR.** This is a build-time batch job, a static-site generator step. There's no server, no database, nothing running at request time. Every time the site builds, one Node script reads each campus's calendar from wherever it lives, mashes the six of them into a single common shape, and writes a handful of static files: a JSON that powers the calendar embedded on the Events page, plus subscribable `.ics` feeds (one per campus and one merged "all"). Those files are served free from GitHub Pages and are what the website and people's calendar apps read.

**Why this design (not Teamup or an off-the-shelf aggregator).** Nothing is authored in a central tool (every campus already maintains its calendar elsewhere), so a hub like Teamup is just a removable middleman, and its free tier can't be an automated hub anyway (paid sync/API, and a 5-calendar cap against our 6 campuses + UCSF + a network calendar). Off-the-shelf mergers don't fit either: two sources aren't iCal (UCSD is a JSON API, UCSC is RSS), and the hosted ones reintroduce a server and drop per-campus feeds. A build-time static build is $0, has nothing to run or break at request time, and no platform caps. The tradeoff we accept: maintaining a few small adapter files when a campus changes its feed format.

Future work:
- #327
- #328
- #329
- #330
- #331
- #332
- #333
- #334