### PR TITLE
Add post: Develop an Open Source Lesson with the UC OSPO Network

### DIFF
--- a/posts/develop-open-source-lesson-cldt/index.md
+++ b/posts/develop-open-source-lesson-cldt/index.md
@@ -1,0 +1,64 @@
+---
+date: 2026-06-15
+draft: true
+title: "Develop an Open Source Lesson with the UC OSPO Network"
+description: "The UC OSPO Network is running four Carpentries Collaborative Lesson Development Training cohorts this summer and fall. We're looking for people to join an already-scoped lesson team or propose a new lesson."
+author: Tim Dennis
+tags: [carpentries, ospo, education, lesson, open-source, ucospo]
+---
+
+The UC OSPO Network is running four Carpentries Collaborative Lesson Development Training (CLDT) cohorts this summer and fall. The software licensing cohort is confirmed and already full.
+
+We're looking for people to fill two roles: join an already-scoped lesson team, or propose a new lesson and form your own team.
+
+## What is Carpentries Collaborative Lesson Development Training (CLDT)?
+
+Teams of 2-5 people spend the training applying backward design to their lesson idea: who they're teaching, what learners need to be able to do, what exercises will help them get there, and how to structure the lesson in the Carpentries Workbench.
+
+By the end of the training, you'll have a complete lesson outline and a working draft of lesson sections.
+
+Carpentries certification requires one additional step: teaching part of the lesson and then debriefing with a trainer about what you learned and how the lesson can be improved.
+
+Before joining the training, at least one team member must have completed Carpentries Instructor Training or Learner-Centered Teaching.
+
+## Option 1: Join the "Librarians as Open Source Stewards" Cohort
+
+This lesson is scoped and ready for a development team. It builds on skills librarians already have: curation, preservation, metadata, and community stewardship, and frames them as open source contributions.
+
+We're looking for 2-4 people to help develop and pilot the lesson.
+
+## Option 2: Propose a New Lesson
+
+If you have a lesson idea that fits the open source and OSPO ecosystem - for example security practices for academic open source, open source in non-CS research, governance models, contributing as a non-coder, or reproducibility and open data - we have one remaining slot available for a new team.
+
+This is not a firm commitment. All that is required to get started is a topic, a rough sense of who you're teaching, and 2-4 colleagues who would work on it with you.
+
+Finished lessons live in the UC OSPO curriculum catalog and are intended to be taught through UC OSPO and partner programs.
+
+From there, there are two possible routes. Lessons can move into the broader Carpentries lesson programs, or they can go through Carpentries Lab, an open peer-review process focused on lesson design, content quality, and accessibility.
+
+Lab-accepted lessons receive a URL on carpentries-lab.org and are publicized through the Carpentries community. The Lab is currently reviewing by invitation, so reaching out early is helpful.
+
+## What Authors Get
+
+Lab acceptance creates the option to submit to JOSE (Journal of Open Source Education). The JOSE review is separate - it evaluates an accompanying paper rather than the lesson itself.
+
+Authors who complete both processes receive a Crossref DOI. The publication is peer-reviewed, indexed by Google Scholar, and remains part of your scholarly record if you move institutions.
+
+The UC OSPO Network will provide editorial support for teams interested in pursuing JOSE publication, including mentorship through the submission and review process.
+
+Lessons that remain institutional can still receive a Zenodo DOI. The UC OSPO Network maintains a Zenodo community connected to our GitHub organization, and DOI minting is part of the publication process before a lesson goes public.
+
+You do not need broad community adoption to receive credit for your work.
+
+The UC OSPO Network provides Workbench-compatible repository templates and setup support, so teams arrive at CLDT ready to build.
+
+Most lessons stall at the pilot stage. We actively create teaching opportunities through UC Carpentries and the CURIOSS network so lessons can be tested and refined.
+
+If contributors move institutions, lessons hosted in the UC OSPO GitHub organization can continue to be maintained through network oversight.
+
+## Express Interest by June 30
+
+Open an issue on GitHub or email [tdennis@library.ucla.edu](mailto:tdennis@library.ucla.edu).
+
+Tell us which option you're responding to, who would be joining you, and, for Option 2, a brief description of the lesson idea.


### PR DESCRIPTION
## Summary

- New blog post announcing CLDT cohorts this summer/fall
- Covers Option 1 (Librarians as Open Source Stewards cohort) and Option 2 (propose a new lesson)
- Includes author benefits: JOSE publication path, Zenodo DOI, Carpentries Lab
- Call to action: express interest by June 30

## Notes

- Date set to 2026-06-15 (Monday publish)
- Marked `draft: true` in frontmatter

## Test plan

- [ ] Preview post renders correctly on the site
- [ ] Remove `draft: true` before merging
- [ ] Verify author/tags display as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)