### PR TITLE
Extend CLDT interest deadline to July 17

### DIFF
--- a/posts/develop-open-source-lesson-cldt/index.md
+++ b/posts/develop-open-source-lesson-cldt/index.md
@@ -50,7 +50,7 @@ We provide Workbench-compatible repository templates and setup support so teams 
 
 If contributors move institutions, lessons hosted in the [UC OSPO GitHub organization](https://github.com/UC-OSPO-Network) can continue to be maintained through network oversight.
 
-## Express interest by June 30
+## Express interest by July 17
 
 Open an issue on [GitHub](https://github.com/UC-OSPO-Network/education/issues/new?template=cldt-interest.yml) or email [tdennis@library.ucla.edu](mailto:tdennis@library.ucla.edu).
 


### PR DESCRIPTION
The post published June 15 with a June 30 deadline. With the email and social push going out the week of June 23, a June 30 cutoff leaves under a week for people to find teammates (Option 1 needs 2-4 people; Option 2 involves team recruitment). Extends to Friday, July 17 for a realistic ~3.5-week window. Cohorts run through summer and fall, so there's room.