### PR TITLE
Flowchart text color

### DIFF
--- a/about/get-involved.md
+++ b/about/get-involved.md
@@ -41,8 +41,8 @@ flowchart TD
     D --> E["Identify a lead contact\nat your institution"]
     E --> F["Welcome aboard! 🎉"]
 
-    style A fill:#fef3c7,color:#000,stroke:#fef3c7
-    style F fill:#fef3c7,color:#000,stroke:#fef3c7
+    style A fill:#fef3c7,stroke:#fef3c7
+    style F fill:#fef3c7,stroke:#fef3c7
 ```
 
 :::

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -485,7 +485,7 @@ footer.article-grid {
 
 /* Ensure mermaid flowchart node text is readable */
 .mermaid-centered .nodeLabel p {
-  color: #222 !important;
+  color: #757575 !important;
 }
 
 /* ── Blog cards ─────────────────────────────────────────────────── */


### PR DESCRIPTION
The text inside flowchart on the get involved page ( https://ucospo.net/about/get-involved/ ) is not legible when viewing the site in dark mode:

<img width="516" height="622" alt="Screenshot 2026-06-30 at 2 29 39 PM" src="https://github.com/user-attachments/assets/a9055fac-ef44-4bb6-9079-6c0b0fa41ee5" />

This PR updates the CSS styling for flowchart text to use a gray color (instead of black), so that the diagram is legible in both light and dark modes! ( e9be4e58931e226ddb7013a99a7ac589ced4a955 )

<img width="444" height="611" alt="Screenshot 2026-06-30 at 2 55 28 PM" src="https://github.com/user-attachments/assets/ef5cddc6-be3e-44cb-b955-4ecd2acb6804" />

I also noticed that the text color was being formatted both in the CSS directory and via inline styling. during local testing, it appears that the CSS overrides the inline color directive, so I removed it to keep things tidy and clear (1cb108a5cab14baa3a2bbf3650a797b172e850ea)