### PR TITLE
try to fix puppeteer/netlify failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ If you push without running pre-commit locally, the `pre-commit.ci` bot will che
 
 ## CI and deployment
 
-The site is deployed to [GitHub Pages](https://pages.github.com) via GitHub Actions.
+The site's production build is deployed to [GitHub Pages](https://pages.github.com) via GitHub Actions.
 
-**On push to `main`:** the site is built, checked (linkinator + pa11y-ci), and deployed to the `gh-pages` branch.
+**On push to `main`:** `.github/workflows/deploy.yml` builds the site with `make html` and publishes it to the `UC-OSPO-Network.github.io` repo (also on a 12-hour schedule, to keep the aggregated event feeds current).
 
-**On pull requests:** the same build and checks run. Branch PRs also get a deploy preview at `ucospo.net/pr-preview/pr-<number>/` (fork PRs get the build check but not the preview).
+**On pull requests:** `.github/workflows/pr.yml` runs the build and checks (linkinator + pa11y-ci). Branch PRs also get a **Netlify deploy preview** (built from `netlify.toml`, linked from the PR's checks); fork PRs get the build check but not the preview. The Netlify preview is not production.
 
 CI checks that run on every PR:
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,10 @@
 [build.environment]
   NODE_VERSION = "20"
+  # pa11y-ci pulls in puppeteer, whose Chrome download is unreliable and breaks
+  # `npm ci` on Netlify's build cache. The Netlify build never runs puppeteer
+  # (myst + feed + events + linkinator only), so skip the download. Mirrors the
+  # PUPPETEER_SKIP_DOWNLOAD fix applied to the GitHub Actions workflows in #342.
+  PUPPETEER_SKIP_DOWNLOAD = "true"
 
 [build]
   publish = "_build/html"


### PR DESCRIPTION
 pa11y-ci pulls in puppeteer, whose Chrome download is unreliable and breaks
`npm ci` on Netlify's build cache. The Netlify build never runs puppeteer
(myst + feed + events + linkinator only), so skip the download. Mirrors the
PUPPETEER_SKIP_DOWNLOAD fix applied to the GitHub Actions workflows in #342.